### PR TITLE
feat: skip Vercel builds when apps/web-next is unchanged

### DIFF
--- a/apps/web-next/vercel.json
+++ b/apps/web-next/vercel.json
@@ -1,0 +1,3 @@
+{
+  "ignoreCommand": "git diff HEAD^ HEAD --quiet -- apps/web-next/"
+}


### PR DESCRIPTION
## Problem
Vercel triggers a preview build for every PR, even when changes don't affect `apps/web-next`.

## Solution
Add `ignoreCommand` to `apps/web-next/vercel.json`. Vercel runs this command before each build:
- exits `0` (no changes in `apps/web-next/`) → build is **skipped**
- exits `1` (changes found) → build **proceeds**

## Changes
- `apps/web-next/vercel.json` — new file with `ignoreCommand`