### PR TITLE
fix: clear budgets during data reset

### DIFF
--- a/apps/web-next/e2e/tests/data-reset.spec.ts
+++ b/apps/web-next/e2e/tests/data-reset.spec.ts
@@ -50,7 +50,7 @@ test.describe("Data Reset", () => {
     await expect(page.getByText(/data reset complete/i)).toBeVisible();
 
     // Verify counts are shown
-    await expect(page.getByText(/budgets deleted/i)).toBeVisible();
+    await expect(page.getByText(/•\s*\d+\s+budgets deleted/i)).toBeVisible();
     await expect(page.getByText(/transactions deleted/i)).toBeVisible();
     await expect(page.getByText(/categories deleted/i)).toBeVisible();
     await expect(page.getByText(/tags deleted/i)).toBeVisible();
@@ -172,7 +172,7 @@ test.describe("Data Reset", () => {
       .click();
 
     await expect(page.getByText(/data reset complete/i)).toBeVisible();
-    await expect(page.getByText(/budgets deleted/i)).toBeVisible();
+    await expect(page.getByText(/•\s*1\s+budgets deleted/i)).toBeVisible();
 
     const { data: budgets } = await supabaseAdmin
       .from("budgets")

--- a/apps/web-next/e2e/tests/data-reset.spec.ts
+++ b/apps/web-next/e2e/tests/data-reset.spec.ts
@@ -5,6 +5,7 @@ import {
   loginUser,
   cleanupReferenceDataForUser,
   seedReferenceDataForUser,
+  createBudget,
   createTransactionWithoutTags,
   supabaseAdmin,
 } from "../utils/test-helpers";
@@ -49,6 +50,7 @@ test.describe("Data Reset", () => {
     await expect(page.getByText(/data reset complete/i)).toBeVisible();
 
     // Verify counts are shown
+    await expect(page.getByText(/budgets deleted/i)).toBeVisible();
     await expect(page.getByText(/transactions deleted/i)).toBeVisible();
     await expect(page.getByText(/categories deleted/i)).toBeVisible();
     await expect(page.getByText(/tags deleted/i)).toBeVisible();
@@ -149,5 +151,42 @@ test.describe("Data Reset", () => {
       .eq("user_id", testUser.userId);
 
     expect(categories).toHaveLength(0);
+  });
+
+  test("data reset removes all budgets and clears dashboard", async ({
+    page,
+  }) => {
+    const ts = Date.now();
+    const budgetName = `e2e-reset-budget-${ts}`;
+
+    await createBudget(page, budgetName, "Spend", "250", "Reset me");
+
+    await page.goto("/");
+    await expect(page.getByRole("heading", { name: budgetName })).toBeVisible();
+
+    await page.goto("/settings");
+    await page.getByText("Danger Zone").scrollIntoViewIfNeeded();
+    await page.getByRole("button", { name: /reset.*data/i }).click();
+    await page
+      .getByRole("button", { name: /yes.*delete.*everything/i })
+      .click();
+
+    await expect(page.getByText(/data reset complete/i)).toBeVisible();
+    await expect(page.getByText(/budgets deleted/i)).toBeVisible();
+
+    const { data: budgets } = await supabaseAdmin
+      .from("budgets")
+      .select("id")
+      .eq("user_id", testUser.userId);
+
+    expect(budgets).toHaveLength(0);
+
+    await page.goto("/");
+    await expect(
+      page.getByText(/no budgets yet/i)
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: budgetName })
+    ).not.toBeVisible();
   });
 });

--- a/apps/web-next/src/pages/settings/index.tsx
+++ b/apps/web-next/src/pages/settings/index.tsx
@@ -67,7 +67,7 @@ interface BulkUploadResult {
 
 interface DataResetResult {
   success: boolean;
-  budgets_deleted: number;
+  budgets_deleted?: number;
   transactions_deleted: number;
   categories_deleted: number;
   tags_deleted: number;
@@ -362,7 +362,7 @@ const DataResetSection: React.FC = () => {
             description={
               <List size="small">
                 <List.Item>
-                  • {result.budgets_deleted} budgets deleted
+                  • {result.budgets_deleted ?? 0} budgets deleted
                 </List.Item>
                 <List.Item>
                   • {result.transactions_deleted} transactions deleted
@@ -422,7 +422,7 @@ const DataResetSection: React.FC = () => {
       >
         <Alert
           message="Warning"
-          description="This will permanently delete ALL your transactions, categories, tags, and bank accounts. This action cannot be undone."
+          description="This will permanently delete ALL your budgets, transactions, categories, tags, and bank accounts. This action cannot be undone."
           type="warning"
           showIcon
         />

--- a/apps/web-next/src/pages/settings/index.tsx
+++ b/apps/web-next/src/pages/settings/index.tsx
@@ -67,6 +67,7 @@ interface BulkUploadResult {
 
 interface DataResetResult {
   success: boolean;
+  budgets_deleted: number;
   transactions_deleted: number;
   categories_deleted: number;
   tags_deleted: number;
@@ -360,6 +361,9 @@ const DataResetSection: React.FC = () => {
             message="Data Reset Complete"
             description={
               <List size="small">
+                <List.Item>
+                  • {result.budgets_deleted} budgets deleted
+                </List.Item>
                 <List.Item>
                   • {result.transactions_deleted} transactions deleted
                 </List.Item>

--- a/supabase/migrations/20260321134117_reset_user_data_delete_budgets.sql
+++ b/supabase/migrations/20260321134117_reset_user_data_delete_budgets.sql
@@ -1,0 +1,52 @@
+-- Update reset_user_data() so Reset All Data also removes user-created budgets.
+CREATE
+OR REPLACE FUNCTION public.reset_user_data () RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+SET
+  search_path = '' AS $$
+DECLARE
+  v_uid uuid;
+  v_transactions_deleted bigint := 0;
+  v_categories_deleted bigint := 0;
+  v_tags_deleted bigint := 0;
+  v_bank_accounts_deleted bigint := 0;
+  v_budgets_deleted bigint := 0;
+BEGIN
+  v_uid := auth.uid();
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'reset_user_data: not authenticated' USING ERRCODE = '28000';
+  END IF;
+
+  -- Delete in FK-safe order. Budgets go first so their linked rows cascade away
+  -- before categories/tags are removed.
+  DELETE FROM public.budgets WHERE user_id = v_uid;
+  GET DIAGNOSTICS v_budgets_deleted = ROW_COUNT;
+
+  DELETE FROM public.transactions WHERE user_id = v_uid;
+  GET DIAGNOSTICS v_transactions_deleted = ROW_COUNT;
+
+  DELETE FROM public.categories WHERE user_id = v_uid;
+  GET DIAGNOSTICS v_categories_deleted = ROW_COUNT;
+
+  DELETE FROM public.tags WHERE user_id = v_uid;
+  GET DIAGNOSTICS v_tags_deleted = ROW_COUNT;
+
+  DELETE FROM public.bank_accounts WHERE user_id = v_uid;
+  GET DIAGNOSTICS v_bank_accounts_deleted = ROW_COUNT;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'budgets_deleted', v_budgets_deleted,
+    'transactions_deleted', v_transactions_deleted,
+    'categories_deleted', v_categories_deleted,
+    'tags_deleted', v_tags_deleted,
+    'bank_accounts_deleted', v_bank_accounts_deleted
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.reset_user_data () IS 'Permanently deletes all personal financial data for the authenticated user, including:
+- All budgets (and their linked budget categories/tags)
+- All transactions
+- All categories
+- All tags
+- All bank accounts';

--- a/supabase/tests/reset_user_data_test.sql
+++ b/supabase/tests/reset_user_data_test.sql
@@ -2,7 +2,7 @@ begin;
 
 create extension if not exists pgtap with schema extensions;
 
-select plan(13);
+select plan(20);
 
 -- Create test users
 select tests.create_supabase_user('reset_user1@test.com');
@@ -27,6 +27,26 @@ insert into public.tags (name) values
 insert into public.bank_accounts (name) values 
   ('Checking'),
   ('Savings');
+
+-- Create budgets with linked category/tag rows
+insert into public.budgets (name, type, target_amount, description)
+values ('Monthly Grocery Budget', 'spend'::public.transaction_type, 300.00, 'Track grocery spending');
+
+insert into public.budget_categories (budget_id, category_id)
+select
+  b.id,
+  c.id
+from public.budgets b
+join public.categories c on c.name = 'Groceries'
+where b.name = 'Monthly Grocery Budget';
+
+insert into public.budget_tags (budget_id, tag_id)
+select
+  b.id,
+  t.id
+from public.budgets b
+join public.tags t on t.name = 'essential'
+where b.name = 'Monthly Grocery Budget';
 
 -- Create transactions
 with ids as (
@@ -63,6 +83,8 @@ select tests.authenticate_as('reset_user2@test.com');
 insert into public.categories (type, name) values ('spend'::public.transaction_type, 'Transport');
 insert into public.tags (name) values ('work');
 insert into public.bank_accounts (name) values ('Monzo');
+insert into public.budgets (name, type, target_amount, description)
+values ('Transport Budget', 'spend'::public.transaction_type, 100.00, 'Keep transport spending in check');
 
 with ids as (
   select
@@ -104,6 +126,21 @@ select ok(
   'Test 1: User 1 has 2 bank accounts before reset'
 );
 
+select ok(
+  (select count(*) from public.budgets) = 1,
+  'Test 1: User 1 has 1 budget before reset'
+);
+
+select ok(
+  (select count(*) from public.budget_categories) = 1,
+  'Test 1: User 1 has 1 budget-category link before reset'
+);
+
+select ok(
+  (select count(*) from public.budget_tags) = 1,
+  'Test 1: User 1 has 1 budget-tag link before reset'
+);
+
 -- ===== Test 2: Execute reset_user_data for User 1 =====
 select lives_ok(
   $$ select public.reset_user_data() $$,
@@ -135,6 +172,24 @@ select is(
   'Test 3: User 1 bank accounts deleted after reset'
 );
 
+select is(
+  (select count(*) from public.budgets),
+  0::bigint,
+  'Test 3: User 1 budgets deleted after reset'
+);
+
+select is(
+  (select count(*) from public.budget_categories),
+  0::bigint,
+  'Test 3: User 1 budget-category links deleted after reset'
+);
+
+select is(
+  (select count(*) from public.budget_tags),
+  0::bigint,
+  'Test 3: User 1 budget-tag links deleted after reset'
+);
+
 -- ===== Test 4: User 2 data is NOT affected =====
 select tests.authenticate_as('reset_user2@test.com');
 
@@ -154,6 +209,12 @@ select results_eq(
   $$ select count(*) from public.transactions $$,
   $$ values (1::bigint) $$,
   'Test 4: User 2 transactions remain intact after user 1 reset'
+);
+
+select results_eq(
+  $$ select count(*) from public.budgets $$,
+  $$ values (1::bigint) $$,
+  'Test 4: User 2 budgets remain intact after user 1 reset'
 );
 
 -- ===== Test 5: Unauthenticated user cannot reset =====


### PR DESCRIPTION
   ## Why
   
   `Reset All Data` did not fully reset a user account because it left user-created budgets behind. That caused old budgets to remain visible on the dashboard 
  even after a successful reset, which made the feature feel incomplete and inconsistent.
   
   Fixes #103.
   
   ## What Changed
   
   Updated `public.reset_user_data()` so it deletes user budgets as part of the reset flow and returns a `budgets_deleted` count in the JSON response.
   
   Added a Supabase migration to apply that function change.
   
   Updated the Settings page success message to show how many budgets were deleted alongside the other reset counts.
   
   Extended database coverage in `supabase/tests/reset_user_data_test.sql` to verify budgets and related budget links are removed for the current user while 
  other users’ budgets remain intact.
   
   Added an E2E test in `apps/web-next/e2e/tests/data-reset.spec.ts` that creates a budget, runs the reset flow, verifies the budget is deleted in the database,
   and confirms the dashboard is cleared.
   
   ## Key Decisions
   
   Budgets are deleted first in the reset function so dependent `budget_categories` and `budget_tags` rows are cleaned up safely before category and tag removal
   continues.
   
   The UI change was kept minimal by extending the existing reset result payload and confirmation list instead of introducing a separate message path.
   
   Coverage was added at both the database and browser levels so the fix is validated in the core reset logic and in the user-facing flow.
   
   ## How This Affects the System
   
   **User-facing impact:** After using `Settings -> Danger Zone -> Reset All Data`, previously created budgets are now removed and no longer appear on the 
  dashboard.
   
   **Database impact:** `reset_user_data()` now deletes rows from `public.budgets` for the authenticated user and reports the deleted count.
   
   **API/function contract impact:** The reset response now includes `budgets_deleted`.
   
   **Breaking changes:** None expected, because this extends the returned payload and aligns behavior with user expectations.
   
   ## Testing
   
   Added pgTAP assertions in `supabase/tests/reset_user_data_test.sql` covering:
   
   - budgets exist before reset
   - budget-category and budget-tag links exist before reset
   - budgets and linked rows are removed after reset
   - another user’s budgets remain unaffected
   
   Added E2E coverage in `apps/web-next/e2e/tests/data-reset.spec.ts` covering:
   
   - budget creation before reset
   - reset confirmation includes budgets deleted
   - budgets table is empty after reset for the test user
   - dashboard no longer shows the deleted budget and shows the empty state