### PR TITLE
feat: add dashboard category sorting

### DIFF
--- a/apps/web-next/src/pages/dashboard/index.tsx
+++ b/apps/web-next/src/pages/dashboard/index.tsx
@@ -2,6 +2,7 @@ import {
   Card,
   Col,
   Row,
+  type TableColumnsType,
   Typography,
   Select,
   Statistic,
@@ -257,20 +258,24 @@ const CategoryBreakdownTable = ({
   loading: boolean;
   type: TransactionType;
 }) => {
-  const filteredData = data
-    .filter((d) => d.type === type)
-    .sort((a, b) => b.total - a.total);
+  const filteredData = data.filter((d) => d.type === type);
 
-  const columns = [
+  const columns: TableColumnsType<CategorySummary> = [
     {
       title: "Category",
       dataIndex: "category_name",
       key: "category_name",
+      sorter: (a: CategorySummary, b: CategorySummary) =>
+        a.category_name.localeCompare(b.category_name),
+      sortDirections: ["ascend", "descend"],
     },
     {
       title: "Amount",
       dataIndex: "total",
       key: "total",
+      sorter: (a: CategorySummary, b: CategorySummary) => a.total - b.total,
+      defaultSortOrder: "descend",
+      sortDirections: ["descend", "ascend"],
       render: (value: number) => formatCurrencyLocal(value),
       align: "right" as const,
     },


### PR DESCRIPTION
## Why
The dashboard category tables for earn, spend, and save were static, which made it harder to inspect data from different angles. Adding built-in sorting improves usability without changing the underlying dashboard data model.

## What Changed
- Updated `apps/web-next/src/pages/dashboard/index.tsx`
- Added alphabetical sorting for the `Category` column
- Added numeric sorting for the `Amount` column
- Kept the table default ordering by amount descending to preserve the previous presentation

## Key Decisions
The change uses Ant Design table column sorters instead of custom controls so it matches the existing UI library behavior and keeps the implementation small.

The default sort order remains amount descending so the tables still open in the same practical order users already saw before this change.

## How This Affects the System
- User-facing changes: dashboard category tables can now be sorted by category name and amount
- API changes: none
- Performance implications: negligible; sorting is handled in the table layer on already-fetched rows
- Database changes: none
- Breaking changes: none expected

## Testing
- Ran `npm run lint src/pages/dashboard/index.tsx` in `apps/web-next`
- Ran `npm run check-types` in `apps/web-next`
- Ran `npm run build` in `apps/web-next`
- Verified the table configuration keeps the previous default amount-desc view while enabling interactive sorting
