### PR TITLE
chore: reorder sidebar navigation

### DIFF
--- a/apps/web-next/src/App.tsx
+++ b/apps/web-next/src/App.tsx
@@ -13,7 +13,6 @@ import {
   AuthPage,
   ErrorComponent,
   ThemedLayout,
-  ThemedSider,
   useNotificationProvider,
 } from "@refinedev/antd";
 import "@refinedev/antd/dist/reset.css";
@@ -25,8 +24,7 @@ import routerProvider, {
   UnsavedChangesNotifier,
 } from "@refinedev/react-router";
 import { dataProvider, liveProvider } from "@refinedev/supabase";
-import { App as AntdApp, Menu } from "antd";
-import type { ComponentProps, FC } from "react";
+import { App as AntdApp } from "antd";
 import { BrowserRouter, Outlet, Route, Routes } from "react-router";
 import authProvider from "./authProvider";
 import { ColorModeContextProvider } from "./contexts/color-mode";
@@ -68,26 +66,6 @@ const I18N_TRANSLATIONS: Record<string, string> = {
   "documentTitle.suffix": " | MoneyLens",
 };
 
-const AppSider: FC<ComponentProps<typeof ThemedSider>> = (props) => (
-  <ThemedSider
-    {...props}
-    render={({ items, logout }) => {
-      const menuItems = Array.isArray(items) ? items : [items];
-
-      return [
-        ...menuItems.slice(0, 1),
-        <Menu.Divider key="divider-dashboard" />,
-        ...menuItems.slice(1, 3),
-        <Menu.Divider key="divider-budgets" />,
-        ...menuItems.slice(3, 6),
-        <Menu.Divider key="divider-tags" />,
-        ...menuItems.slice(6, 7),
-        <Menu.Divider key="divider-settings" />,
-        logout,
-      ].filter(Boolean);
-    }}
-  />
-);
 
 function App() {
   return (
@@ -202,11 +180,7 @@ function App() {
                       fallback={<CatchAllNavigate to="/login" />}
                     >
                       <EnvironmentBanner />
-                      <ThemedLayout
-                        Header={Header}
-                        Title={ProjectTitle}
-                        Sider={AppSider}
-                      >
+                      <ThemedLayout Header={Header} Title={ProjectTitle}>
                         <Outlet />
                       </ThemedLayout>
                     </Authenticated>
@@ -298,7 +272,7 @@ function App() {
                 <Route
                   element={
                     <Authenticated key="catch-all">
-                      <ThemedLayout Sider={AppSider}>
+                      <ThemedLayout>
                         <Outlet />
                       </ThemedLayout>
                     </Authenticated>

--- a/apps/web-next/src/App.tsx
+++ b/apps/web-next/src/App.tsx
@@ -13,6 +13,7 @@ import {
   AuthPage,
   ErrorComponent,
   ThemedLayout,
+  ThemedSider,
   useNotificationProvider,
 } from "@refinedev/antd";
 import "@refinedev/antd/dist/reset.css";
@@ -24,7 +25,8 @@ import routerProvider, {
   UnsavedChangesNotifier,
 } from "@refinedev/react-router";
 import { dataProvider, liveProvider } from "@refinedev/supabase";
-import { App as AntdApp } from "antd";
+import { App as AntdApp, Menu } from "antd";
+import type { ComponentProps, FC } from "react";
 import { BrowserRouter, Outlet, Route, Routes } from "react-router";
 import authProvider from "./authProvider";
 import { ColorModeContextProvider } from "./contexts/color-mode";
@@ -65,6 +67,27 @@ const I18N_TRANSLATIONS: Record<string, string> = {
   "documentTitle.default": "MoneyLens",
   "documentTitle.suffix": " | MoneyLens",
 };
+
+const AppSider: FC<ComponentProps<typeof ThemedSider>> = (props) => (
+  <ThemedSider
+    {...props}
+    render={({ items, logout }) => {
+      const menuItems = Array.isArray(items) ? items : [items];
+
+      return [
+        ...menuItems.slice(0, 1),
+        <Menu.Divider key="divider-dashboard" />,
+        ...menuItems.slice(1, 3),
+        <Menu.Divider key="divider-budgets" />,
+        ...menuItems.slice(3, 6),
+        <Menu.Divider key="divider-tags" />,
+        ...menuItems.slice(6, 7),
+        <Menu.Divider key="divider-settings" />,
+        logout,
+      ].filter(Boolean);
+    }}
+  />
+);
 
 function App() {
   return (
@@ -122,13 +145,6 @@ function App() {
                   },
                 },
                 {
-                  name: "categories",
-                  list: "/categories",
-                  create: "/categories/create",
-                  edit: "/categories/edit/:id",
-                  show: "/categories/show/:id",
-                },
-                {
                   name: "budgets",
                   list: "/budgets",
                   create: "/budgets/create",
@@ -140,17 +156,12 @@ function App() {
                   },
                 },
                 {
-                  name: "tags",
-                  list: "/tags",
-                  create: "/tags/create",
-                  edit: "/tags/edit/:id",
-                  show: "/tags/show/:id",
-                  meta: {
-                    label: "Tags",
-                    icon: <TagsOutlined />,
-                  },
+                  name: "categories",
+                  list: "/categories",
+                  create: "/categories/create",
+                  edit: "/categories/edit/:id",
+                  show: "/categories/show/:id",
                 },
-
                 {
                   name: "bank_accounts", // Database table name
                   list: "/bank-accounts",
@@ -160,6 +171,17 @@ function App() {
                   meta: {
                     label: "Bank Accounts",
                     icon: <BankOutlined />,
+                  },
+                },
+                {
+                  name: "tags",
+                  list: "/tags",
+                  create: "/tags/create",
+                  edit: "/tags/edit/:id",
+                  show: "/tags/show/:id",
+                  meta: {
+                    label: "Tags",
+                    icon: <TagsOutlined />,
                   },
                 },
                 {
@@ -180,7 +202,11 @@ function App() {
                       fallback={<CatchAllNavigate to="/login" />}
                     >
                       <EnvironmentBanner />
-                      <ThemedLayout Header={Header} Title={ProjectTitle}>
+                      <ThemedLayout
+                        Header={Header}
+                        Title={ProjectTitle}
+                        Sider={AppSider}
+                      >
                         <Outlet />
                       </ThemedLayout>
                     </Authenticated>
@@ -272,7 +298,7 @@ function App() {
                 <Route
                   element={
                     <Authenticated key="catch-all">
-                      <ThemedLayout>
+                      <ThemedLayout Sider={AppSider}>
                         <Outlet />
                       </ThemedLayout>
                     </Authenticated>


### PR DESCRIPTION
## Why
The application navigation needed to be reorganized so the most important sections appear in a clearer, more intentional order with visible grouping between major areas.

## What Changed
- Reordered the Refine resource definitions in apps/web-next/src/App.tsx
- Added a custom AppSider wrapper around Refines ThemedSider
- Used the sider render hook to insert Menu.Divider elements between menu sections
- Applied the custom sider to both the authenticated app layout and the authenticated catch-all layout

The resulting order is:
- Dashboard
- divider
- Transactions
- Budgets
- divider
- Categories
- Bank Accounts
- Tags
- divider
- Settings
- divider
- Logout

## Key Decisions
I used Refines built-in ThemedSider with its render hook instead of replacing the full sidebar implementation. This keeps the change localized, preserves Refines existing access control and menu behavior, and only customizes the final rendered item order.

## How This Affects the System
- User-facing change: the sidebar menu order and grouping are updated
- No API changes
- No database changes
- No breaking changes expected
- Minimal implementation risk because the change is isolated to app layout rendering

## Testing
- Ran: cd apps/web-next && npm run check-types
- Ran: cd apps/web-next && npm run lint -- src/App.tsx
- Verified only apps/web-next/src/App.tsx was committed for this change