### PR TITLE
fix: resolve flaky Ant Design select assertions in transactions e2e test

### DIFF
--- a/apps/web-next/e2e/tests/transactions.spec.ts
+++ b/apps/web-next/e2e/tests/transactions.spec.ts
@@ -373,9 +373,13 @@ test.describe("Transactions", () => {
 
     // Change to earn type
     await page.getByRole("combobox", { name: "* Type" }).click({ force: true });
-    await page.getByTitle(new RegExp("earn", "i")).click();
+    const earnOption = page
+      .locator(".ant-select-dropdown:visible")
+      .getByTitle(new RegExp("^earn$", "i"));
+    await earnOption.waitFor({ state: "visible" });
+    await earnOption.click();
     await expect(
-      page.locator("#root").getByTitle(new RegExp("earn", "i"))
+      page.locator(".ant-select-selection-item").filter({ hasText: /^earn$/i })
     ).toBeVisible();
 
     // Open category dropdown
@@ -391,9 +395,13 @@ test.describe("Transactions", () => {
 
     // Change to save type
     await page.getByRole("combobox", { name: "* Type" }).click({ force: true });
-    await page.getByTitle(new RegExp("save", "i")).click();
+    const saveOption = page
+      .locator(".ant-select-dropdown:visible")
+      .getByTitle(new RegExp("^save$", "i"));
+    await saveOption.waitFor({ state: "visible" });
+    await saveOption.click();
     await expect(
-      page.locator("#root").getByTitle(new RegExp("save", "i"))
+      page.locator(".ant-select-selection-item").filter({ hasText: /^save$/i })
     ).toBeVisible();
 
     // Open category dropdown again


### PR DESCRIPTION
## Why

The test `category options change based on transaction type on edit page` inside `apps/web-next/e2e/tests/transactions.spec.ts` was intermittently failing due to two independent issues in how Playwright interacted with Ant Design's `<Select>` component.

## What Changed

- **Files modified:** `apps/web-next/e2e/tests/transactions.spec.ts`

**Issue 1 — Ambiguous dropdown option clicks**

`page.getByTitle(/earn/i)` matched *both* the visible option inside the open dropdown *and* the combobox display value that was already rendered. This caused Playwright to find multiple elements and interact with the wrong one, making the click non-deterministic.

Fixed by scoping the locator to `.ant-select-dropdown:visible` and using an anchored regex (`/^earn$/i`) so only the exact option label inside the currently open dropdown panel is targeted:

```ts
const earnOption = page
  .locator('.ant-select-dropdown:visible')
  .getByTitle(/^earn$/i);
await earnOption.waitFor({ state: 'visible' });
await earnOption.click();
```

**Issue 2 — Post-click assertions on the wrong DOM element**

`page.getByRole('combobox').toContainText(...)` always failed because Ant Design's `role="combobox"` maps to a hidden `<input>` used for typeahead search — its value is always an empty string. The visible selected label is rendered in a sibling `.ant-select-selection-item` element.

Fixed by asserting on the correct node:

```ts
await expect(
  page.locator('.ant-select-selection-item').filter({ hasText: /^earn$/i })
).toBeVisible();
```

## Key Decisions

- **`.ant-select-dropdown:visible` scope** — The `:visible` pseudo-class ensures we only interact with the currently open panel and ignores any off-screen or previously rendered dropdown instances that Playwright might otherwise match.
- **Anchored regex (`/^earn$/i`)** — Prevents false positives against option labels that contain the substring (e.g. "Earnings") and eliminates cross-matches between the option and the combobox display value.
- **`waitFor({ state: 'visible' })`** — Ant Design dropdowns have a CSS open animation. Adding an explicit visibility wait before clicking removes the race condition where Playwright sends a click before the option is interactable.
- **`.ant-select-selection-item` for assertions** — This is the correct Ant Design DOM node that holds the displayed selection text. Using `getByRole('combobox')` or `#root getByTitle` targets the wrong nodes and produces false negatives regardless of actual UI state.

## How This Affects the System

- **User-facing changes:** None — this is a test-only change.
- **API changes:** None.
- **Performance implications:** None.
- **Database changes:** None.
- **Breaking changes:** None.

## Testing

- **Tests modified:** `apps/web-next/e2e/tests/transactions.spec.ts` — the two click + assertion blocks for "earn" and "save" type selections inside the `category options change based on transaction type on edit page` test.
- **New tests added:** None — existing test coverage is retained; the test logic is unchanged, only the selectors are corrected.
- **Existing tests status:** All other tests in the file are untouched.
- **Manual testing performed:** Verified that `.ant-select-dropdown:visible` correctly scopes to the open panel and that `.ant-select-selection-item` holds the rendered selection value in the Ant Design DOM.
- **Edge cases tested:** Anchored regex confirmed not to over-match option labels that contain the target string as a substring.