### PR TITLE
chore: add Ant Design Select and form validation patterns to e2e skill

### DIFF
--- a/.agents/skills/e2e-tests/SKILL.md
+++ b/.agents/skills/e2e-tests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: End-to-End Test Implementation
-description: Implement end-to-end tests for web-next Web Application using Playwright to ensure application functionality. Use when asked to create, update, or maintain e2e tests.
+description: Implement, fix, or refactor end-to-end Playwright tests for the web-next application. Use when asked to write tests, add coverage, fix flaky tests, or update tests after a feature change. Trigger phrases: "write e2e tests for X", "add playwright tests", "test this feature", "this test is failing/flaky", "update tests for the new X page".
 ---
 
 # End-to-End Test Implementation
@@ -138,10 +138,55 @@ The application structure is as follows:
   await page.getByRole("combobox", { name: "* Type" }).click();
 ```
 
-** Locate Filled Selector **
+** Select an Option from an Ant Design Dropdown **
+
+Always scope the option click to `.ant-select-dropdown:visible` and use an anchored regex. This is the correct pattern for clicking an option in an open Ant Design `<Select>` dropdown:
+
 ```typescript
-    await page.getByText(new RegExp(categoryType, "i")).click();
+  // Open the dropdown first
+  await page.getByRole("combobox", { name: "* Type" }).click({ force: true });
+
+  // Then click the option scoped to the visible dropdown
+  const option = page
+    .locator(".ant-select-dropdown:visible")
+    .getByTitle(new RegExp(`^${categoryType}$`, "i"));
+  await option.waitFor({ state: "visible" });
+  await option.click();
 ```
+
+**Why NOT `getByText`:**
+- `getByText(new RegExp(categoryType, "i"))` matches every element on the page that contains the text — including the combobox display value, table cells, labels, and other unrelated text. This causes ambiguous multi-match errors and, worse, may silently click the wrong element.
+- After an option is clicked, Ant Design briefly keeps the dropdown in the DOM while animating out. The newly selected value also appears in `.ant-select-selection-item` on the same frame. A `getByText` query at that moment resolves to multiple elements and the click lands on the detaching dropdown node, not the target — causing the "element detached from DOM" flake.
+- Scoping to `.ant-select-dropdown:visible` guarantees the locator only matches the open dropdown overlay, making the click unambiguous and stable.
+
+**Verify the selection after clicking** using `.ant-select-selection-item`, not the combobox input (which is always empty in Ant Design):
+
+```typescript
+  await expect(
+    page.locator(".ant-select-selection-item").filter({ hasText: new RegExp(`^${categoryType}$`, "i") })
+  ).toBeVisible();
+```
+
+** Handle Ant Design Form Validation Errors **
+
+Always use `getByRole("alert")` to assert validation errors — never `getByText` with the hardcoded message string:
+
+```typescript
+// Submit empty form to trigger validation
+await page.getByRole("button", { name: /save/i }).click();
+
+// Assert the error is visible
+await expect(page.getByRole("alert").first()).toBeVisible();
+
+// Assert the error disappears after filling the field
+await page.getByRole("textbox", { name: "* Name" }).fill("some value");
+await expect(page.getByRole("alert")).toHaveCount(0);
+```
+
+**Why NOT `getByText("'name' is required")`:**
+- Ant Design's default validation message (`'name' is required`) is generated from the field name and can change if the field label, locale, or validation config changes — breaking the test silently.
+- `getByRole("alert")` is the semantic locator for Ant Design's `<Form.Item>` error nodes and is stable regardless of message content or locale.
+- If you need to assert a *specific* error message (e.g. to distinguish between two errors), use `getByRole("alert").filter({ hasText: /required/i })` rather than exact string matching.
 
 ---
 **Summary:**


### PR DESCRIPTION
## Why

The E2E test skill's `## Useful Patterns` section contained outdated guidance that actively causes flaky tests in the moneylens test suite:

1. **Ant Design Select** — the old `getByText(new RegExp(categoryType, "i")).click()` pattern matches every element on the page that contains the text (labels, table cells, the combobox display value) and is the root cause of recurring `"element detached from DOM"` failures. Ant Design briefly keeps the closing dropdown in the DOM while the newly selected value simultaneously appears in `.ant-select-selection-item`, so `getByText` hits a detaching node rather than the stable option.

2. **Form validation errors** — asserting `getByText("'name' is required")` is fragile. Ant Design generates this message from the field name; any change to the label, locale, or validation config silently breaks the test without a code change.

3. **Skill description** — the frontmatter only mentioned *creation* scenarios, so the skill was not being triggered when a developer asked to fix a flaky test or update tests after a feature change.

## What Changed

- **Files updated:** `.agents/skills/e2e-tests/SKILL.md`
- **New pattern added (Select dropdown):** scope the option click to `.ant-select-dropdown:visible` and use an anchored regex with `getByTitle`. Add `waitFor({ state: "visible" })` before clicking. Assert the selected value via `.ant-select-selection-item` (the combobox `<input>` is always empty in Ant Design and cannot be used for assertions).
- **New pattern added (form validation):** use `getByRole("alert")` to assert validation error presence/absence. Documents why `getByText` with a hardcoded message string is brittle and gives a safe alternative for asserting a *specific* message with `.filter({ hasText: /required/i })`.
- **Skill description updated:** added richer trigger phrases — `"fix flaky tests"`, `"update tests after a feature change"`, `"this test is failing/flaky"` — so the skill fires in remediation and refactor contexts, not just greenfield test creation.

## Key Decisions

- **Scope locators to `.ant-select-dropdown:visible` rather than the full page.** This is the minimal change that eliminates ambiguity; it works regardless of how many other Select components are on the page.
- **Use `getByTitle` with anchored regex instead of `getByText`.** Ant Design renders the option label as the `title` attribute on the list item, which is unique and stable. `getByText` also matches partial-text nodes outside the dropdown.
- **Prefer `getByRole("alert")` over text content.** Ant Design's `<Form.Item>` error output uses `role="alert"` semantically, making it locale- and label-agnostic.
- **Pattern explanations are written as inline `Why NOT` blocks** immediately below each code example so future contributors understand the trade-offs without having to look elsewhere.

## How This Affects the System

- **User-facing changes:** None — this is a skill documentation file only.
- **API changes:** None.
- **Performance implications:** None.
- **Database changes:** None.
- **Breaking changes:** None. The old pattern snippets are replaced, not deprecated; any existing tests that already follow the old pattern will continue to run (the skill change only affects future test authoring guidance).

## Testing

- **New tests added:** None — this PR updates agent skill documentation, not application code.
- **Existing tests status:** Unaffected; no source or test files were modified.
- **Manual testing performed:** Verified the updated locator strategy (`.ant-select-dropdown:visible` + `getByTitle`) against the Ant Design Select component in the app — confirmed it resolves to exactly one node with no ambiguity and no detached-DOM errors.
- **Edge cases tested:** Confirmed the anchored regex (`^${categoryType}$`) does not accidentally match option labels that are substrings of other labels (e.g. "Food" vs "Fast Food").
- **Test files modified or added:** None.