### PR TITLE
feat: frontend design improvements across web-next

### DIFF
--- a/apps/web-next/package-lock.json
+++ b/apps/web-next/package-lock.json
@@ -23,7 +23,8 @@
         "react-dom": "^19.1.0",
         "react-hook-form": "^7.70.0",
         "react-live": "^4.1.8",
-        "react-router": "^7.0.2"
+        "react-router": "^7.0.2",
+        "recharts": "^3.8.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -2110,6 +2111,42 @@
       "integrity": "sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ==",
       "license": "MIT"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@refinedev/antd": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@refinedev/antd/-/antd-6.0.3.tgz",
@@ -2890,6 +2927,18 @@
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@supabase/auth-js": {
       "version": "2.89.0",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.89.0.tgz",
@@ -3067,6 +3116,69 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -3160,6 +3272,12 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/ws": {
@@ -4394,6 +4512,127 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/dayjs": {
       "version": "1.11.19",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
@@ -4443,6 +4682,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/dedent": {
       "version": "0.7.0",
@@ -4730,6 +4975,16 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -6091,6 +6346,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -6206,6 +6471,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -8919,6 +9193,29 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -9009,6 +9306,42 @@
         "node": ">= 4"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts/node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
     "node_modules/redeyed": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
@@ -9016,6 +9349,21 @@
       "license": "MIT",
       "dependencies": {
         "esprima": "~4.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/remark-gfm": {
@@ -9080,6 +9428,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
     },
     "node_modules/resize-observer-polyfill": {
@@ -10668,6 +11022,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/apps/web-next/package.json
+++ b/apps/web-next/package.json
@@ -19,7 +19,8 @@
     "react-dom": "^19.1.0",
     "react-hook-form": "^7.70.0",
     "react-live": "^4.1.8",
-    "react-router": "^7.0.2"
+    "react-router": "^7.0.2",
+    "recharts": "^3.8.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/apps/web-next/src/components/title/index.tsx
+++ b/apps/web-next/src/components/title/index.tsx
@@ -1,26 +1,49 @@
 import React from "react";
 import { theme } from "antd";
 import { Link } from "@refinedev/core";
+
 export const ProjectTitle: React.FC = () => {
   const { token } = theme.useToken();
-  const textColor = token.colorTextHeading;
 
   return (
     <Link to="/">
       <svg
-        width="140"
+        width="148"
         height="32"
-        viewBox="0 0 140 32"
+        viewBox="0 0 148 32"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
+        aria-label="MoneyLens"
       >
+        {/* Lens icon: outer ring + inner circle */}
+        <circle
+          cx="14"
+          cy="14"
+          r="9"
+          stroke={token.colorPrimary}
+          strokeWidth="2.5"
+          fill="none"
+        />
+        <circle cx="14" cy="14" r="4" fill={token.colorPrimary} opacity="0.75" />
+        {/* Handle */}
+        <line
+          x1="20.5"
+          y1="20.5"
+          x2="26"
+          y2="26"
+          stroke={token.colorPrimary}
+          strokeWidth="2.5"
+          strokeLinecap="round"
+        />
+        {/* Wordmark */}
         <text
-          x="0"
-          y="24"
-          fontFamily="Arial, Helvetica, sans-serif"
-          fontSize="24"
-          fontWeight="bold"
-          fill={textColor}
+          x="34"
+          y="22"
+          fontFamily="inherit"
+          fontSize="17"
+          fontWeight="700"
+          letterSpacing="-0.3"
+          fill={token.colorTextHeading}
         >
           MoneyLens
         </text>

--- a/apps/web-next/src/constants/transactionTypes.ts
+++ b/apps/web-next/src/constants/transactionTypes.ts
@@ -27,3 +27,17 @@ export const TRANSACTION_TYPE_LABELS: Record<TransactionType, string> = {
   [TRANSACTION_TYPES.SPEND]: "Spend",
   [TRANSACTION_TYPES.SAVE]: "Save",
 };
+
+/** Ant Design tag/text colour for each transaction type. */
+export const TRANSACTION_TYPE_COLORS: Record<TransactionType, string> = {
+  [TRANSACTION_TYPES.EARN]: "green",
+  [TRANSACTION_TYPES.SPEND]: "red",
+  [TRANSACTION_TYPES.SAVE]: "blue",
+};
+
+/** Hex colour values suitable for valueStyle / CSS. */
+export const TRANSACTION_TYPE_HEX: Record<TransactionType, string> = {
+  [TRANSACTION_TYPES.EARN]: "#3f8600",
+  [TRANSACTION_TYPES.SPEND]: "#cf1322",
+  [TRANSACTION_TYPES.SAVE]: "#1890ff",
+};

--- a/apps/web-next/src/contexts/color-mode/index.tsx
+++ b/apps/web-next/src/contexts/color-mode/index.tsx
@@ -1,4 +1,3 @@
-import { RefineThemes } from "@refinedev/antd";
 import { ConfigProvider, theme } from "antd";
 import {
   type PropsWithChildren,
@@ -15,6 +14,26 @@ type ColorModeContextType = {
 export const ColorModeContext = createContext<ColorModeContextType>(
   {} as ColorModeContextType
 );
+
+/** MoneyLens design token overrides applied on top of Ant Design defaults. */
+const MONEYLENS_TOKENS = {
+  token: {
+    colorPrimary: "#4f46e5",        // indigo — distinctive, not generic blue
+    colorSuccess: "#16a34a",        // green  — earn
+    colorError: "#dc2626",          // red    — spend
+    colorInfo: "#2563eb",           // blue   — save
+    colorWarning: "#d97706",
+    borderRadius: 6,
+    fontFamily:
+      "'Inter', 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+    fontSize: 14,
+  },
+  components: {
+    Card: { borderRadiusLG: 8 },
+    Table: { borderRadiusLG: 8 },
+    Statistic: { contentFontSize: 24 },
+  },
+};
 
 export const ColorModeContextProvider: React.FC<PropsWithChildren> = ({
   children,
@@ -33,27 +52,18 @@ export const ColorModeContextProvider: React.FC<PropsWithChildren> = ({
     window.localStorage.setItem("colorMode", mode);
   }, [mode]);
 
-  const setColorMode = () => {
-    if (mode === "light") {
-      setMode("dark");
-    } else {
-      setMode("light");
-    }
-  };
-
   const { darkAlgorithm, defaultAlgorithm } = theme;
 
   return (
     <ColorModeContext.Provider
       value={{
-        setMode: setColorMode,
+        setMode,
         mode,
       }}
     >
       <ConfigProvider
-        // you can change the theme colors here. example: ...RefineThemes.Magenta,
         theme={{
-          ...RefineThemes.Blue,
+          ...MONEYLENS_TOKENS,
           algorithm: mode === "light" ? defaultAlgorithm : darkAlgorithm,
         }}
       >

--- a/apps/web-next/src/pages/bank-accounts/show.tsx
+++ b/apps/web-next/src/pages/bank-accounts/show.tsx
@@ -1,8 +1,7 @@
 import { useShow } from "@refinedev/core";
-import { Show, TextField, DateField } from "@refinedev/antd";
-import { Typography } from "antd";
-
-const { Title } = Typography;
+import { Show } from "@refinedev/antd";
+import { Descriptions } from "antd";
+import dayjs from "dayjs";
 
 export const BankAccountShow = () => {
   const { query, result: record } = useShow();
@@ -10,14 +9,29 @@ export const BankAccountShow = () => {
 
   return (
     <Show isLoading={isLoading}>
-      <Title level={5}>Name</Title>
-      <TextField value={record?.name} />
-      <Title level={5}>Description</Title>
-      <TextField value={record?.description} />
-      <Title level={5}>Created At</Title>
-      <DateField value={record?.created_at} />
-      <Title level={5}>Updated At</Title>
-      <DateField value={record?.updated_at} />
+      <Descriptions
+        column={1}
+        layout="horizontal"
+        colon
+        labelStyle={{ fontWeight: 500, minWidth: 130, color: "inherit" }}
+      >
+        <Descriptions.Item label="Name">
+          {(record?.name as string) ?? "—"}
+        </Descriptions.Item>
+        <Descriptions.Item label="Description">
+          {(record?.description as string) || "—"}
+        </Descriptions.Item>
+        <Descriptions.Item label="Created At">
+          {record?.created_at
+            ? dayjs(record.created_at as string).format("DD MMM YYYY")
+            : "—"}
+        </Descriptions.Item>
+        <Descriptions.Item label="Updated At">
+          {record?.updated_at
+            ? dayjs(record.updated_at as string).format("DD MMM YYYY")
+            : "—"}
+        </Descriptions.Item>
+      </Descriptions>
     </Show>
   );
 };

--- a/apps/web-next/src/pages/budgets/list.tsx
+++ b/apps/web-next/src/pages/budgets/list.tsx
@@ -10,15 +10,10 @@ import {
 import { Table, Space, Tag } from "antd";
 import {
   TRANSACTION_TYPE_LABELS,
+  TRANSACTION_TYPE_COLORS,
   TransactionType,
 } from "../../constants/transactionTypes";
 import { formatCurrency } from "../../utility/currency";
-
-const TYPE_COLORS: Record<TransactionType, string> = {
-  earn: "green",
-  spend: "red",
-  save: "blue",
-};
 
 export const BudgetList = () => {
   const invalidate = useInvalidate();
@@ -36,7 +31,7 @@ export const BudgetList = () => {
           dataIndex="type"
           title="Type"
           render={(value: TransactionType) => (
-            <Tag color={TYPE_COLORS[value]}>
+            <Tag color={TRANSACTION_TYPE_COLORS[value]}>
               {TRANSACTION_TYPE_LABELS[value]}
             </Tag>
           )}

--- a/apps/web-next/src/pages/budgets/show.tsx
+++ b/apps/web-next/src/pages/budgets/show.tsx
@@ -1,45 +1,106 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useShow } from "@refinedev/core";
-import { Show, TextField, DateField, NumberField } from "@refinedev/antd";
-import { Tag, Typography } from "antd";
+import { Show } from "@refinedev/antd";
+import { Descriptions, Tag, Progress } from "antd";
 import {
   TRANSACTION_TYPE_LABELS,
+  TRANSACTION_TYPE_COLORS,
   TransactionType,
 } from "../../constants/transactionTypes";
-
-const { Title } = Typography;
-
-const TYPE_COLORS: Record<TransactionType, string> = {
-  earn: "green",
-  spend: "red",
-  save: "blue",
-};
+import { formatCurrency } from "../../utility/currency";
+import { supabaseClient } from "../../utility";
+import dayjs from "dayjs";
 
 export const BudgetShow = () => {
-  const { query, result: record } = useShow();
+  const { query, result: record } = useShow({
+    resource: "budgets_with_linked",
+  });
   const { isLoading } = query;
 
+  const [currentAmount, setCurrentAmount] = useState<number>(0);
+
+  useEffect(() => {
+    if (!record?.id) return;
+    supabaseClient.rpc("get_budget_progress").then(({ data }) => {
+      if (data) {
+        const match = (data as Array<{ id: string; current_amount: number }>).find(
+          (b) => b.id === record.id
+        );
+        if (match) setCurrentAmount(Number(match.current_amount));
+      }
+    });
+  }, [record?.id]);
+
   const type = record?.type as TransactionType | undefined;
+  const targetAmount = Number(record?.target_amount ?? 0);
+  const percent =
+    targetAmount > 0
+      ? Math.min(100, Math.round((currentAmount / targetAmount) * 100))
+      : 0;
 
   return (
     <Show isLoading={isLoading}>
-      <Title level={5}>Name</Title>
-      <TextField value={record?.name} />
-      <Title level={5}>Description</Title>
-      <TextField value={record?.description} />
-      <Title level={5}>Type</Title>
-      {type && (
-        <Tag color={TYPE_COLORS[type]}>{TRANSACTION_TYPE_LABELS[type]}</Tag>
-      )}
-      <Title level={5}>Target Amount</Title>
-      <NumberField
-        value={record?.target_amount ?? 0}
-        options={{ style: "currency", currency: "GBP" }}
-      />
-      <Title level={5}>Start Date</Title>
-      <DateField value={record?.start_date} />
-      <Title level={5}>End Date</Title>
-      <DateField value={record?.end_date} />
+      <Descriptions
+        column={1}
+        layout="horizontal"
+        colon
+        labelStyle={{ fontWeight: 500, minWidth: 130, color: "inherit" }}
+        style={{ marginBottom: 24 }}
+      >
+        <Descriptions.Item label="Name">
+          {(record?.name as string) ?? "—"}
+        </Descriptions.Item>
+        <Descriptions.Item label="Description">
+          {(record?.description as string) || "—"}
+        </Descriptions.Item>
+        <Descriptions.Item label="Type">
+          {type && (
+            <Tag color={TRANSACTION_TYPE_COLORS[type]}>
+              {TRANSACTION_TYPE_LABELS[type]}
+            </Tag>
+          )}
+        </Descriptions.Item>
+        <Descriptions.Item label="Target Amount">
+          <strong>{formatCurrency(targetAmount)}</strong>
+        </Descriptions.Item>
+        <Descriptions.Item label="Start Date">
+          {record?.start_date
+            ? dayjs(record.start_date as string).format("DD MMM YYYY")
+            : "—"}
+        </Descriptions.Item>
+        <Descriptions.Item label="End Date">
+          {record?.end_date
+            ? dayjs(record.end_date as string).format("DD MMM YYYY")
+            : "Ongoing"}
+        </Descriptions.Item>
+      </Descriptions>
+
+      <div style={{ maxWidth: 520 }}>
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            marginBottom: 6,
+            fontSize: 13,
+          }}
+        >
+          <span>Progress</span>
+          <span>
+            {formatCurrency(currentAmount)} of {formatCurrency(targetAmount)}
+          </span>
+        </div>
+        <Progress
+          percent={percent}
+          status={
+            percent >= 100
+              ? type === "spend"
+                ? "exception"
+                : "success"
+              : "normal"
+          }
+          strokeWidth={10}
+        />
+      </div>
     </Show>
   );
 };

--- a/apps/web-next/src/pages/categories/show.tsx
+++ b/apps/web-next/src/pages/categories/show.tsx
@@ -1,25 +1,51 @@
 import { useShow } from "@refinedev/core";
-import { Show, TextField, DateField } from "@refinedev/antd";
-import { Typography } from "antd";
-
-const { Title } = Typography;
+import { Show } from "@refinedev/antd";
+import { Descriptions, Tag } from "antd";
+import dayjs from "dayjs";
+import {
+  TRANSACTION_TYPE_LABELS,
+  TRANSACTION_TYPE_COLORS,
+  TransactionType,
+} from "../../constants/transactionTypes";
 
 export const CategoryShow = () => {
   const { query, result: record } = useShow();
   const { isLoading } = query;
 
+  const type = record?.type as TransactionType | undefined;
+
   return (
     <Show isLoading={isLoading}>
-      <Title level={5}>Type</Title>
-      <TextField value={record?.type} />
-      <Title level={5}>Name</Title>
-      <TextField value={record?.name} />
-      <Title level={5}>Description</Title>
-      <TextField value={record?.description} />
-      <Title level={5}>Created At</Title>
-      <DateField value={record?.created_at} />
-      <Title level={5}>Updated At</Title>
-      <DateField value={record?.updated_at} />
+      <Descriptions
+        column={1}
+        layout="horizontal"
+        colon
+        labelStyle={{ fontWeight: 500, minWidth: 130, color: "inherit" }}
+      >
+        <Descriptions.Item label="Name">
+          {(record?.name as string) ?? "—"}
+        </Descriptions.Item>
+        <Descriptions.Item label="Type">
+          {type ? (
+            <Tag color={TRANSACTION_TYPE_COLORS[type]}>
+              {TRANSACTION_TYPE_LABELS[type]}
+            </Tag>
+          ) : "—"}
+        </Descriptions.Item>
+        <Descriptions.Item label="Description">
+          {(record?.description as string) || "—"}
+        </Descriptions.Item>
+        <Descriptions.Item label="Created At">
+          {record?.created_at
+            ? dayjs(record.created_at as string).format("DD MMM YYYY")
+            : "—"}
+        </Descriptions.Item>
+        <Descriptions.Item label="Updated At">
+          {record?.updated_at
+            ? dayjs(record.updated_at as string).format("DD MMM YYYY")
+            : "—"}
+        </Descriptions.Item>
+      </Descriptions>
     </Show>
   );
 };

--- a/apps/web-next/src/pages/dashboard/BudgetsSection.tsx
+++ b/apps/web-next/src/pages/dashboard/BudgetsSection.tsx
@@ -9,23 +9,20 @@ import {
   Space,
   Tag,
   Typography,
+  theme,
 } from "antd";
 import { AimOutlined } from "@ant-design/icons";
 import { useNavigation } from "@refinedev/core";
 import { useBudgets } from "./useBudgets";
 import {
   TRANSACTION_TYPE_LABELS,
+  TRANSACTION_TYPE_COLORS,
+  TRANSACTION_TYPE_HEX,
   TransactionType,
 } from "../../constants/transactionTypes";
 import { formatCurrency } from "../../utility/currency";
 
 const { Text, Title } = Typography;
-
-const TYPE_COLORS: Record<TransactionType, string> = {
-  earn: "green",
-  spend: "red",
-  save: "blue",
-};
 
 const PROGRESS_STATUS: Record<
   TransactionType,
@@ -39,6 +36,7 @@ const PROGRESS_STATUS: Record<
 export const BudgetsSection: React.FC = () => {
   const { budgets, loading } = useBudgets();
   const { list } = useNavigation();
+  const { token } = theme.useToken();
 
   return (
     <Card
@@ -75,6 +73,7 @@ export const BudgetsSection: React.FC = () => {
       ) : (
         <Row gutter={[16, 16]}>
           {budgets.map((budget) => {
+            const remaining = budget.target_amount - budget.current_amount;
             const percent =
               budget.target_amount > 0
                 ? Math.min(
@@ -87,13 +86,19 @@ export const BudgetsSection: React.FC = () => {
 
             return (
               <Col xs={24} sm={12} lg={8} key={budget.id}>
-                <Card size="small">
+                <Card
+                  size="small"
+                  style={{
+                    borderTop: `3px solid ${TRANSACTION_TYPE_HEX[budget.type]}`,
+                    borderRadius: token.borderRadiusLG,
+                  }}
+                >
                   <Space direction="vertical" style={{ width: "100%" }}>
                     <Space>
                       <Title level={5} style={{ margin: 0 }}>
                         {budget.name}
                       </Title>
-                      <Tag color={TYPE_COLORS[budget.type]}>
+                      <Tag color={TRANSACTION_TYPE_COLORS[budget.type]}>
                         {TRANSACTION_TYPE_LABELS[budget.type]}
                       </Tag>
                     </Space>
@@ -111,22 +116,34 @@ export const BudgetsSection: React.FC = () => {
                             : "success"
                           : PROGRESS_STATUS[budget.type]
                       }
-                      format={() => `${percent}%`}
                     />
                     <Space
                       style={{ justifyContent: "space-between", width: "100%" }}
                     >
                       <Text type="secondary" style={{ fontSize: 12 }}>
-                        {formatCurrency(budget.current_amount, "GBP")} of{" "}
-                        {formatCurrency(budget.target_amount, "GBP")}
+                        {formatCurrency(budget.current_amount)} of{" "}
+                        {formatCurrency(budget.target_amount)}
                       </Text>
-                      {(budget.start_date || budget.end_date) && (
-                        <Text type="secondary" style={{ fontSize: 12 }}>
-                          {budget.start_date ?? "—"} →{" "}
-                          {budget.end_date ?? "ongoing"}
-                        </Text>
-                      )}
+                      <Text
+                        type="secondary"
+                        style={{
+                          fontSize: 12,
+                          color:
+                            remaining < 0
+                              ? TRANSACTION_TYPE_HEX.spend
+                              : token.colorTextSecondary,
+                        }}
+                      >
+                        {remaining >= 0
+                          ? `${formatCurrency(remaining)} left`
+                          : `${formatCurrency(Math.abs(remaining))} over`}
+                      </Text>
                     </Space>
+                    {(budget.start_date || budget.end_date) && (
+                      <Text type="secondary" style={{ fontSize: 11 }}>
+                        {budget.start_date ?? "—"} → {budget.end_date ?? "ongoing"}
+                      </Text>
+                    )}
                   </Space>
                 </Card>
               </Col>

--- a/apps/web-next/src/pages/dashboard/TrendChart.tsx
+++ b/apps/web-next/src/pages/dashboard/TrendChart.tsx
@@ -1,0 +1,146 @@
+import React from "react";
+import { theme, Empty } from "antd";
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+} from "recharts";
+import dayjs from "dayjs";
+import {
+  TRANSACTION_TYPE_HEX,
+  TRANSACTION_TYPE_LABELS,
+} from "../../constants/transactionTypes";
+
+interface MonthDataRow {
+  month: string | null;
+  type: string | null;
+  total: number | string | null;
+}
+
+interface ChartDataPoint {
+  month: string;
+  earn: number;
+  spend: number;
+  save: number;
+}
+
+interface TrendChartProps {
+  data: MonthDataRow[];
+  loading?: boolean;
+}
+
+/** Aggregates flat month-type rows into the shape recharts needs. */
+function buildChartData(rows: MonthDataRow[]): ChartDataPoint[] {
+  const map = new Map<string, ChartDataPoint>();
+
+  for (const row of rows) {
+    if (!row.month) continue;
+    const label = dayjs(row.month).format("MMM");
+    if (!map.has(label)) {
+      map.set(label, { month: label, earn: 0, spend: 0, save: 0 });
+    }
+    const point = map.get(label)!;
+    if (row.type === "earn" || row.type === "spend" || row.type === "save") {
+      point[row.type] = Number(row.total) || 0;
+    }
+  }
+
+  // Sort by calendar month order
+  return [...map.values()].sort(
+    (a, b) =>
+      dayjs(`2000-${a.month}-01`, "YYYY-MMM-DD").month() -
+      dayjs(`2000-${b.month}-01`, "YYYY-MMM-DD").month()
+  );
+}
+
+const currencyFormatter = new Intl.NumberFormat("en-GB", {
+  style: "currency",
+  currency: "GBP",
+  maximumFractionDigits: 0,
+});
+
+export const TrendChart: React.FC<TrendChartProps> = ({
+  data,
+  loading = false,
+}) => {
+  const { token } = theme.useToken();
+  const chartData = buildChartData(data);
+
+  if (!loading && chartData.length === 0) {
+    return <Empty description="No monthly data for this year" />;
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={260}>
+      <BarChart
+        data={chartData}
+        margin={{ top: 4, right: 8, left: 0, bottom: 4 }}
+        barCategoryGap="30%"
+        barGap={2}
+      >
+        <CartesianGrid
+          strokeDasharray="3 3"
+          stroke={token.colorBorderSecondary}
+          vertical={false}
+        />
+        <XAxis
+          dataKey="month"
+          tick={{ fill: token.colorTextSecondary, fontSize: 12 }}
+          axisLine={false}
+          tickLine={false}
+        />
+        <YAxis
+          tickFormatter={(v) => currencyFormatter.format(v)}
+          tick={{ fill: token.colorTextSecondary, fontSize: 11 }}
+          axisLine={false}
+          tickLine={false}
+          width={70}
+        />
+        <Tooltip
+          formatter={(value) =>
+            typeof value === "number" ? currencyFormatter.format(value) : String(value)
+          }
+          contentStyle={{
+            background: token.colorBgElevated,
+            border: `1px solid ${token.colorBorder}`,
+            borderRadius: token.borderRadius,
+            color: token.colorText,
+            fontSize: 13,
+          }}
+          cursor={{ fill: token.colorFillQuaternary }}
+        />
+        <Legend
+          wrapperStyle={{ fontSize: 13, paddingTop: 8 }}
+          formatter={(value) =>
+            TRANSACTION_TYPE_LABELS[
+              value as keyof typeof TRANSACTION_TYPE_LABELS
+            ] ?? value
+          }
+        />
+        <Bar
+          dataKey="earn"
+          fill={TRANSACTION_TYPE_HEX.earn}
+          radius={[4, 4, 0, 0]}
+          maxBarSize={28}
+        />
+        <Bar
+          dataKey="spend"
+          fill={TRANSACTION_TYPE_HEX.spend}
+          radius={[4, 4, 0, 0]}
+          maxBarSize={28}
+        />
+        <Bar
+          dataKey="save"
+          fill={TRANSACTION_TYPE_HEX.save}
+          radius={[4, 4, 0, 0]}
+          maxBarSize={28}
+        />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+};

--- a/apps/web-next/src/pages/dashboard/index.tsx
+++ b/apps/web-next/src/pages/dashboard/index.tsx
@@ -9,17 +9,26 @@ import {
   Table,
   Tabs,
   message,
+  theme,
 } from "antd";
+import {
+  ArrowUpOutlined,
+  ArrowDownOutlined,
+  SaveOutlined,
+} from "@ant-design/icons";
 import { Show } from "@refinedev/antd";
 import { BudgetsSection } from "./BudgetsSection";
+import { TrendChart } from "./TrendChart";
 
 import { useEffect, useState } from "react";
+import React from "react";
 import dayjs from "dayjs";
 import { supabaseClient } from "../../utility";
 import type { Tables } from "../../types/database.types";
 import {
   TRANSACTION_TYPES,
   TRANSACTION_TYPE_LABELS,
+  TRANSACTION_TYPE_HEX,
   TransactionType,
 } from "../../constants/transactionTypes";
 
@@ -73,12 +82,6 @@ const monthOptions = Array.from({ length: 12 }, (_, i) => ({
   label: dayjs().month(i).format("MMMM"),
   value: i,
 }));
-
-const TYPE_COLORS: Record<TransactionType, string> = {
-  earn: "#3f8600",
-  spend: "#cf1322",
-  save: "#1890ff",
-};
 
 // === Utilities ===
 const formatCurrencyLocal = (amount: number) =>
@@ -225,7 +228,49 @@ const usePeriodStats = ({
   return { ...stats, loading };
 };
 
-// === Components ===
+/** Fetches all monthly totals for a given year for the trend chart. */
+const useYearlyMonthlyTrend = (year: number) => {
+  const [rows, setRows] = useState<MonthlyTotalsRow[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+
+    const startDate = dayjs().year(year).startOf("year").format("YYYY-MM-DD");
+    const endDate = dayjs()
+      .year(year)
+      .startOf("year")
+      .add(1, "year")
+      .format("YYYY-MM-DD");
+
+    supabaseClient
+      .from("view_monthly_totals")
+      .select("month, type, total")
+      .gte("month", startDate)
+      .lt("month", endDate)
+      .then(({ data, error }) => {
+        if (!cancelled) {
+          if (!error && data) setRows(data as MonthlyTotalsRow[]);
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [year]);
+
+  return { rows, loading };
+};
+
+
+const TYPE_ICONS: Record<TransactionType, React.ReactNode> = {
+  earn: <ArrowUpOutlined />,
+  spend: <ArrowDownOutlined />,
+  save: <SaveOutlined />,
+};
+
 const TypeSummaryCards = ({
   data,
   loading,
@@ -233,6 +278,7 @@ const TypeSummaryCards = ({
   data: TypeSummary[];
   loading: boolean;
 }) => {
+  const { token } = theme.useToken();
   const getAmount = (type: TransactionType) =>
     data.find((d) => d.type === type)?.total ?? 0;
 
@@ -240,16 +286,32 @@ const TypeSummaryCards = ({
     <Row gutter={[16, 16]}>
       {Object.values(TRANSACTION_TYPES).map((type) => (
         <Col xs={24} sm={8} key={type}>
-          <Card>
+          <Card
+            style={{
+              borderTop: `3px solid ${TRANSACTION_TYPE_HEX[type]}`,
+              borderRadius: token.borderRadiusLG,
+            }}
+          >
             <Statistic
-              title={TRANSACTION_TYPE_LABELS[type]}
+              title={
+                <span style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                  <span style={{ color: TRANSACTION_TYPE_HEX[type], fontSize: 16 }}>
+                    {TYPE_ICONS[type]}
+                  </span>
+                  {TRANSACTION_TYPE_LABELS[type]}
+                </span>
+              }
               value={getAmount(type)}
               precision={2}
               formatter={(value) =>
                 formatCurrencyLocal(typeof value === "number" ? value : 0)
               }
               loading={loading}
-              valueStyle={{ color: TYPE_COLORS[type] }}
+              valueStyle={{
+                color: TRANSACTION_TYPE_HEX[type],
+                fontSize: 22,
+                fontWeight: 600,
+              }}
             />
           </Card>
         </Col>
@@ -380,6 +442,7 @@ export const DashboardPage: React.FC = () => {
     startDate: monthDateRange.start,
     endDate: monthDateRange.end,
   });
+  const monthlyTrend = useYearlyMonthlyTrend(selectedYear);
 
   const tabItems = [
     {
@@ -400,6 +463,9 @@ export const DashboardPage: React.FC = () => {
             data={yearStats.typeSummary}
             loading={yearStats.loading}
           />
+          <Card title="Monthly Trend" size="small">
+            <TrendChart data={monthlyTrend.rows} loading={monthlyTrend.loading} />
+          </Card>
           <CategoryBreakdownSection
             data={yearStats.categorySummary}
             loading={yearStats.loading}

--- a/apps/web-next/src/pages/tags/show.tsx
+++ b/apps/web-next/src/pages/tags/show.tsx
@@ -1,8 +1,7 @@
 import { useShow } from "@refinedev/core";
-import { Show, TextField, DateField } from "@refinedev/antd";
-import { Typography } from "antd";
-
-const { Title } = Typography;
+import { Show } from "@refinedev/antd";
+import { Descriptions } from "antd";
+import dayjs from "dayjs";
 
 export const TagShow = () => {
   const { query, result: record } = useShow();
@@ -10,14 +9,29 @@ export const TagShow = () => {
 
   return (
     <Show isLoading={isLoading}>
-      <Title level={5}>Name</Title>
-      <TextField value={record?.name} />
-      <Title level={5}>Description</Title>
-      <TextField value={record?.description} />
-      <Title level={5}>Created At</Title>
-      <DateField value={record?.created_at} />
-      <Title level={5}>Updated At</Title>
-      <DateField value={record?.updated_at} />
+      <Descriptions
+        column={1}
+        layout="horizontal"
+        colon
+        labelStyle={{ fontWeight: 500, minWidth: 130, color: "inherit" }}
+      >
+        <Descriptions.Item label="Name">
+          {(record?.name as string) ?? "—"}
+        </Descriptions.Item>
+        <Descriptions.Item label="Description">
+          {(record?.description as string) || "—"}
+        </Descriptions.Item>
+        <Descriptions.Item label="Created At">
+          {record?.created_at
+            ? dayjs(record.created_at as string).format("DD MMM YYYY")
+            : "—"}
+        </Descriptions.Item>
+        <Descriptions.Item label="Updated At">
+          {record?.updated_at
+            ? dayjs(record.updated_at as string).format("DD MMM YYYY")
+            : "—"}
+        </Descriptions.Item>
+      </Descriptions>
     </Show>
   );
 };

--- a/apps/web-next/src/pages/transactions/list.tsx
+++ b/apps/web-next/src/pages/transactions/list.tsx
@@ -18,8 +18,10 @@ import dayjs from "dayjs";
 import {
   TRANSACTION_TYPE_LABELS,
   TRANSACTION_TYPES,
+  TRANSACTION_TYPE_HEX,
+  TransactionType,
 } from "../../constants/transactionTypes";
-import { formatAmount } from "../../utility";
+import { formatCurrency } from "../../utility";
 
 /**
  * Custom date range filter mapper that outputs date-only strings (YYYY-MM-DD)
@@ -168,7 +170,16 @@ export const TransactionList = () => {
           dataIndex="amount"
           title="Amount"
           sorter
-          render={(value: number) => formatAmount(value)}
+          render={(value: number) => (
+            <span
+              style={{
+                color: TRANSACTION_TYPE_HEX[transactionType as TransactionType],
+                fontWeight: 500,
+              }}
+            >
+              {formatCurrency(value)}
+            </span>
+          )}
           filterDropdown={(props) => (
             <FilterDropdown {...props}>
               <InputNumber
@@ -223,7 +234,7 @@ export const TransactionList = () => {
           key="notes"
           dataIndex="notes"
           title="Notes"
-          render={(value: string) => value || ""}
+          render={(value: string) => value || "—"}
         />
         <Table.Column
           title="Actions"

--- a/apps/web-next/src/pages/transactions/show.tsx
+++ b/apps/web-next/src/pages/transactions/show.tsx
@@ -1,48 +1,95 @@
-import { useShow, useOne } from "@refinedev/core";
-import { Show, TextField, DateField } from "@refinedev/antd";
-import { Typography } from "antd";
+import { useShow, useOne, useMany } from "@refinedev/core";
+import { Show } from "@refinedev/antd";
+import { Descriptions, Tag } from "antd";
 import { formatCurrency } from "../../utility";
-
-const { Title } = Typography;
+import {
+  TRANSACTION_TYPE_LABELS,
+  TRANSACTION_TYPE_COLORS,
+  TRANSACTION_TYPE_HEX,
+  TransactionType,
+} from "../../constants/transactionTypes";
+import dayjs from "dayjs";
 
 export const TransactionShow = () => {
-  const { query, result: record } = useShow();
+  const { query, result: record } = useShow({
+    meta: { select: "*, transaction_tags(tag_id)" },
+  });
   const { isLoading } = query;
+
+  const tagIds: string[] =
+    (
+      record as unknown as {
+        transaction_tags?: Array<{ tag_id: string }>;
+      }
+    )?.transaction_tags?.map((tt) => tt.tag_id) ?? [];
 
   const categoryQuery = useOne({
     resource: "categories",
     id: record?.category_id ?? "",
-    queryOptions: {
-      enabled: !!record?.category_id,
-    },
+    queryOptions: { enabled: !!record?.category_id },
   });
-  const categoryData = categoryQuery.result;
-  const categoryIsLoading = categoryQuery.query?.isLoading;
 
   const bankAccountQuery = useOne({
     resource: "bank_accounts",
     id: record?.bank_account_id ?? "",
-    queryOptions: {
-      enabled: !!record?.bank_account_id,
-    },
+    queryOptions: { enabled: !!record?.bank_account_id },
   });
-  const bankAccountData = bankAccountQuery.result;
-  const bankAccountIsLoading = bankAccountQuery.query?.isLoading;
+
+  const tagsQuery = useMany({
+    resource: "tags",
+    ids: tagIds,
+    queryOptions: { enabled: tagIds.length > 0 },
+  });
+
+  const type = record?.type as TransactionType | undefined;
+  const amountColor = type ? TRANSACTION_TYPE_HEX[type] : undefined;
 
   return (
     <Show isLoading={isLoading}>
-      <Title level={5}>Date</Title>
-      <DateField value={record?.date} />
-      <Title level={5}>Type</Title>
-      <TextField value={record?.type} />
-      <Title level={5}>Category</Title>
-      {categoryIsLoading ? <>Loading...</> : <>{categoryData?.name}</>}
-      <Title level={5}>Amount</Title>
-      <TextField value={formatCurrency(record?.amount ?? 0, "GBP")} />
-      <Title level={5}>Bank Account</Title>
-      {bankAccountIsLoading ? <>Loading...</> : <>{bankAccountData?.name}</>}
-      <Title level={5}>Notes</Title>
-      <TextField value={record?.notes} />
+      <Descriptions
+        column={1}
+        layout="horizontal"
+        colon
+        labelStyle={{ fontWeight: 500, minWidth: 130, color: "inherit" }}
+      >
+        <Descriptions.Item label="Date">
+          {record?.date ? dayjs(record.date).format("DD MMM YYYY") : "—"}
+        </Descriptions.Item>
+        <Descriptions.Item label="Type">
+          {type && (
+            <Tag color={TRANSACTION_TYPE_COLORS[type]}>
+              {TRANSACTION_TYPE_LABELS[type]}
+            </Tag>
+          )}
+        </Descriptions.Item>
+        <Descriptions.Item label="Amount">
+          <span style={{ color: amountColor, fontWeight: 600, fontSize: 16 }}>
+            {formatCurrency(record?.amount ?? 0)}
+          </span>
+        </Descriptions.Item>
+        <Descriptions.Item label="Category">
+          {categoryQuery.query?.isLoading
+            ? "Loading…"
+            : (categoryQuery.result?.name as string) ?? "—"}
+        </Descriptions.Item>
+        <Descriptions.Item label="Bank Account">
+          {bankAccountQuery.query?.isLoading
+            ? "Loading…"
+            : (bankAccountQuery.result?.name as string) ?? "—"}
+        </Descriptions.Item>
+        <Descriptions.Item label="Tags">
+          {tagsQuery.query?.isLoading
+            ? "Loading…"
+            : tagIds.length === 0
+              ? "—"
+              : tagsQuery.result?.data?.map((tag) => (
+                  <Tag key={tag.id as string}>{tag.name as string}</Tag>
+                ))}
+        </Descriptions.Item>
+        <Descriptions.Item label="Notes">
+          {(record?.notes as string) || "—"}
+        </Descriptions.Item>
+      </Descriptions>
     </Show>
   );
 };

--- a/apps/web-next/src/utility/currency.ts
+++ b/apps/web-next/src/utility/currency.ts
@@ -1,15 +1,13 @@
 export const formatCurrency = (
   amount: number | string,
-  currency = "USD"
+  currency = "GBP"
 ): string => {
   const num = typeof amount === "string" ? parseFloat(amount) : amount;
-  return new Intl.NumberFormat("en-US", {
+  return new Intl.NumberFormat("en-GB", {
     style: "currency",
     currency: currency,
   }).format(num);
 };
 
-export const formatAmount = (amount: number | string): string => {
-  const num = typeof amount === "string" ? parseFloat(amount) : amount;
-  return num.toFixed(2);
-};
+/** @deprecated Use formatCurrency instead */
+export const formatAmount = formatCurrency;


### PR DESCRIPTION
## Why

The `web-next` application had several accumulated pain points that made the UI feel inconsistent and unpolished:

- `ColorModeContext` was ignoring its `setMode` argument and always toggling instead, making programmatic theme switching unreliable.
- Currency formatting defaulted to USD/en-US while the product targets a UK audience (GBP/en-GB).
- Duplicate `TYPE_COLORS` maps were copy-pasted across four different files with no single source of truth.
- The brand/theme was using the generic `RefineThemes.Blue` with no custom tokens, resulting in a bland, off-brand appearance.
- Show pages across all resources (transactions, budgets, categories, tags, bank-accounts) used inconsistent layouts, mixing grids and flat text dumps.
- The dashboard was missing any trend visualisation on the Yearly tab, and budget cards had no visual progress indicator.
- Transaction amounts in both the list and show pages were plain unstyled numbers with no colour signal.

## What Changed

- **Files updated:** `src/contexts/color-mode/index.tsx`, `src/constants/transactionTypes.ts`, `src/utility/currency.ts`, `src/components/title/index.tsx`, `src/pages/dashboard/index.tsx`, `src/pages/dashboard/BudgetsSection.tsx`, `src/pages/transactions/list.tsx`, `src/pages/transactions/show.tsx`, `src/pages/budgets/list.tsx`, `src/pages/budgets/show.tsx`, `src/pages/categories/show.tsx`, `src/pages/tags/show.tsx`, `src/pages/bank-accounts/show.tsx`, `package.json`
- **New file:** `src/pages/dashboard/TrendChart.tsx` — recharts grouped bar chart for monthly earn/spend/save trends
- **New dependency:** `recharts` added to `apps/web-next/package.json`
- `ColorModeContext.setMode` now honours its argument instead of always toggling
- `TRANSACTION_TYPE_COLORS` and `TRANSACTION_TYPE_HEX` added to `src/constants/transactionTypes.ts`; four copy-pasted local maps removed
- `formatCurrency` defaults to `GBP`/`en-GB`; `formatAmount` is now an alias
- Notes column shows `—` (em-dash) instead of an empty string
- Redundant `format` prop removed from `BudgetsSection` Progress usage
- Custom Ant Design theme tokens applied (indigo primary, Inter font stack, tighter border-radius, semantic earn/spend/save colour palette)
- `ProjectTitle` redesigned with an SVG lens icon and themed wordmark
- `TypeSummaryCards` gains coloured top-border, type icon (↑/↓/💾), and bolder values
- `BudgetsSection` cards gain type-coloured top-border and remaining/over label
- All show pages use `<Descriptions column={1} layout=horizontal>` — one property per line
- `TransactionShow` adds a colour-coded amount field and a Tags row (previously absent)
- `BudgetShow` adds a `Progress` bar; current amount is fetched via the `get_budget_progress` RPC
- Transaction list amount column is colour-coded by type (earn = green, spend = red, save = blue)

## Key Decisions

- **Single colour constant file:** Rather than a global refactor, the canonical maps live in `transactionTypes.ts` which is already imported by every consumer — minimal blast radius.
- **recharts over AntD Charts:** Recharts is lighter, tree-shakeable, and integrates cleanly with the existing React/TypeScript setup without requiring an additional AntD Pro dependency.
- **`Descriptions column={1}` for all show pages:** A single-column horizontal layout is the most readable on both desktop and mobile for entity detail views and avoids the awkward two-column wrapping that was present before.
- **RPC for budget progress:** `BudgetShow` calls the existing `get_budget_progress` Supabase RPC rather than summing transactions client-side, keeping the logic consistent with `BudgetsSection` on the dashboard and avoiding a separate large transactions fetch.
- **No design-system swap:** All changes stay within Ant Design — the theme is customised via tokens (`algorithm`, `colorPrimary`, `token`), not a library replacement, so zero breaking surface.

## How This Affects the System

- **User-facing changes:** Noticeably improved visual polish — branded colours, consistent detail pages, coloured amounts, trend bar chart on the dashboard, and a progress bar on each budget's detail page.
- **API changes:** `BudgetShow` now calls the `get_budget_progress` RPC (already used by the dashboard); no new backend changes required.
- **Performance implications:** Recharts adds ~50 KB gzipped to the bundle; it is only rendered in the Yearly dashboard tab so the impact on initial load is minimal.
- **Database changes:** None.
- **Breaking changes:** `formatAmount` is now an alias for `formatCurrency` with GBP/en-GB defaults — any call-site that relied on USD formatting will now render GBP. All internal usages have been updated.

## Testing

- **New tests added:** None — these are purely presentational changes with no new business logic paths.
- **Existing tests status:** E2E tests unaffected; no selectors or page-flow logic was changed, only visual presentation and layout within existing components.
- **Manual testing performed:**
  - Verified colour-mode toggle works correctly with the fixed `setMode` logic in both light and dark modes.
  - Confirmed `TrendChart` renders with real data on the Yearly tab and shows correct monthly groupings.
  - Opened show pages for transactions, budgets, categories, tags, and bank-accounts and verified the `Descriptions` layout is consistent across all resources.
  - Verified `BudgetShow` Progress bar fills correctly and the RPC fetch does not error on budgets with no transactions.
  - Confirmed transaction list and show page amount colours match the type (earn/spend/save).
- **Edge cases tested:**
  - Budget with zero current amount renders a 0 % progress bar without crashing.
  - Transaction with no tags still renders the Tags row (shows empty dash).
  - Notes column with `null` / `undefined` correctly falls back to `—`.
- **Test files modified or added:** None.