### PR TITLE
fix(transactions): use 'between' operator for date range filter

### DIFF
--- a/apps/web-next/src/App.tsx
+++ b/apps/web-next/src/App.tsx
@@ -74,221 +74,223 @@ function App() {
         <ColorModeContextProvider>
           <CurrencyContextProvider>
             <AntdApp>
-            <Refine
-              dataProvider={withSoftDelete(
-                dataProvider(supabaseClient),
-                supabaseClient
-              )}
-              liveProvider={liveProvider(supabaseClient)}
-              authProvider={authProvider}
-              routerProvider={routerProvider}
-              notificationProvider={useNotificationProvider}
-              i18nProvider={{
-                translate: (
-                  key: string,
-                  options?: object | string,
-                  defaultValue?: string
-                ) => {
-                  if (Object.hasOwn(I18N_TRANSLATIONS, key))
-                    return I18N_TRANSLATIONS[key];
-                  const fallback =
-                    typeof options === "string" ? options : defaultValue;
-                  return fallback ?? key;
-                },
-                changeLocale: () => Promise.resolve(),
-                getLocale: () => "en",
-              }}
-              options={{
-                syncWithLocation: true,
-                warnWhenUnsavedChanges: true,
-                projectId: "f28RTa-zPdRQM-EApdtq",
-              }}
-              resources={[
-                {
-                  name: "dashboard",
-                  list: "/",
-                  meta: {
-                    label: "Dashboard",
-                    icon: <DashboardOutlined />,
+              <Refine
+                dataProvider={withSoftDelete(
+                  dataProvider(supabaseClient),
+                  supabaseClient
+                )}
+                liveProvider={liveProvider(supabaseClient)}
+                authProvider={authProvider}
+                routerProvider={routerProvider}
+                notificationProvider={useNotificationProvider}
+                i18nProvider={{
+                  translate: (
+                    key: string,
+                    options?: object | string,
+                    defaultValue?: string
+                  ) => {
+                    if (Object.hasOwn(I18N_TRANSLATIONS, key))
+                      return I18N_TRANSLATIONS[key];
+                    const fallback =
+                      typeof options === "string" ? options : defaultValue;
+                    return fallback ?? key;
                   },
-                },
-                {
-                  name: "transactions",
-                  list: "/transactions",
-                  create: "/transactions/create",
-                  edit: "/transactions/edit/:id",
-                  show: "/transactions/show/:id",
-                  meta: {
-                    label: "Transactions",
-                    icon: <SwapOutlined />,
+                  changeLocale: () => Promise.resolve(),
+                  getLocale: () => "en",
+                }}
+                options={{
+                  syncWithLocation: true,
+                  warnWhenUnsavedChanges: true,
+                  projectId: "f28RTa-zPdRQM-EApdtq",
+                }}
+                resources={[
+                  {
+                    name: "dashboard",
+                    list: "/",
+                    meta: {
+                      label: "Dashboard",
+                      icon: <DashboardOutlined />,
+                    },
                   },
-                },
-                {
-                  name: "budgets",
-                  list: "/budgets",
-                  create: "/budgets/create",
-                  edit: "/budgets/edit/:id",
-                  show: "/budgets/show/:id",
-                  meta: {
-                    label: "Budgets",
-                    icon: <AimOutlined />,
+                  {
+                    name: "transactions",
+                    list: "/transactions",
+                    create: "/transactions/create",
+                    edit: "/transactions/edit/:id",
+                    show: "/transactions/show/:id",
+                    meta: {
+                      label: "Transactions",
+                      icon: <SwapOutlined />,
+                    },
                   },
-                },
-                {
-                  name: "categories",
-                  list: "/categories",
-                  create: "/categories/create",
-                  edit: "/categories/edit/:id",
-                  show: "/categories/show/:id",
-                },
-                {
-                  name: "bank_accounts", // Database table name
-                  list: "/bank-accounts",
-                  create: "/bank-accounts/create",
-                  edit: "/bank-accounts/edit/:id",
-                  show: "/bank-accounts/show/:id",
-                  meta: {
-                    label: "Bank Accounts",
-                    icon: <BankOutlined />,
+                  {
+                    name: "budgets",
+                    list: "/budgets",
+                    create: "/budgets/create",
+                    edit: "/budgets/edit/:id",
+                    show: "/budgets/show/:id",
+                    meta: {
+                      label: "Budgets",
+                      icon: <AimOutlined />,
+                    },
                   },
-                },
-                {
-                  name: "tags",
-                  list: "/tags",
-                  create: "/tags/create",
-                  edit: "/tags/edit/:id",
-                  show: "/tags/show/:id",
-                  meta: {
-                    label: "Tags",
-                    icon: <TagsOutlined />,
+                  {
+                    name: "categories",
+                    list: "/categories",
+                    create: "/categories/create",
+                    edit: "/categories/edit/:id",
+                    show: "/categories/show/:id",
                   },
-                },
-                {
-                  name: "settings",
-                  list: "/settings",
-                  meta: {
-                    label: "Settings",
-                    icon: <SettingOutlined />,
+                  {
+                    name: "bank_accounts", // Database table name
+                    list: "/bank-accounts",
+                    create: "/bank-accounts/create",
+                    edit: "/bank-accounts/edit/:id",
+                    show: "/bank-accounts/show/:id",
+                    meta: {
+                      label: "Bank Accounts",
+                      icon: <BankOutlined />,
+                    },
                   },
-                },
-              ]}
-            >
-              <Routes>
-                <Route
-                  element={
-                    <Authenticated
-                      key="authenticated-routes"
-                      fallback={<CatchAllNavigate to="/login" />}
-                    >
-                      <EnvironmentBanner />
-                      <ThemedLayout Header={Header} Title={ProjectTitle}>
-                        <ErrorBoundary>
-                          <Outlet />
-                        </ErrorBoundary>
-                      </ThemedLayout>
-                    </Authenticated>
-                  }
-                >
-                  <Route index element={<DashboardPage />} />
-                  <Route path="transactions">
-                    <Route index element={<TransactionList />} />
-                    <Route path="create" element={<TransactionCreate />} />
-                    <Route path="edit/:id" element={<TransactionEdit />} />
-                    <Route path="show/:id" element={<TransactionShow />} />
+                  {
+                    name: "tags",
+                    list: "/tags",
+                    create: "/tags/create",
+                    edit: "/tags/edit/:id",
+                    show: "/tags/show/:id",
+                    meta: {
+                      label: "Tags",
+                      icon: <TagsOutlined />,
+                    },
+                  },
+                  {
+                    name: "settings",
+                    list: "/settings",
+                    meta: {
+                      label: "Settings",
+                      icon: <SettingOutlined />,
+                    },
+                  },
+                ]}
+              >
+                <Routes>
+                  <Route
+                    element={
+                      <Authenticated
+                        key="authenticated-routes"
+                        fallback={<CatchAllNavigate to="/login" />}
+                      >
+                        <EnvironmentBanner />
+                        <ThemedLayout Header={Header} Title={ProjectTitle}>
+                          <ErrorBoundary>
+                            <Outlet />
+                          </ErrorBoundary>
+                        </ThemedLayout>
+                      </Authenticated>
+                    }
+                  >
+                    <Route index element={<DashboardPage />} />
+                    <Route path="transactions">
+                      <Route index element={<TransactionList />} />
+                      <Route path="create" element={<TransactionCreate />} />
+                      <Route path="edit/:id" element={<TransactionEdit />} />
+                      <Route path="show/:id" element={<TransactionShow />} />
+                    </Route>
+
+                    <Route path="categories">
+                      <Route index element={<CategoryList />} />
+                      <Route path="create" element={<CategoryCreate />} />
+                      <Route path="edit/:id" element={<CategoryEdit />} />
+                      <Route path="show/:id" element={<CategoryShow />} />
+                    </Route>
+
+                    <Route path="bank-accounts">
+                      <Route index element={<BankAccountList />} />
+                      <Route path="create" element={<BankAccountCreate />} />
+                      <Route path="edit/:id" element={<BankAccountEdit />} />
+                      <Route path="show/:id" element={<BankAccountShow />} />
+                    </Route>
+
+                    <Route path="tags">
+                      <Route index element={<TagList />} />
+                      <Route path="create" element={<TagCreate />} />
+                      <Route path="edit/:id" element={<TagEdit />} />
+                      <Route path="show/:id" element={<TagShow />} />
+                    </Route>
+
+                    <Route path="budgets">
+                      <Route index element={<BudgetList />} />
+                      <Route path="create" element={<BudgetCreate />} />
+                      <Route path="edit/:id" element={<BudgetEdit />} />
+                      <Route path="show/:id" element={<BudgetShow />} />
+                    </Route>
+
+                    <Route path="settings" element={<SettingsPage />} />
                   </Route>
 
-                  <Route path="categories">
-                    <Route index element={<CategoryList />} />
-                    <Route path="create" element={<CategoryCreate />} />
-                    <Route path="edit/:id" element={<CategoryEdit />} />
-                    <Route path="show/:id" element={<CategoryShow />} />
-                  </Route>
-
-                  <Route path="bank-accounts">
-                    <Route index element={<BankAccountList />} />
-                    <Route path="create" element={<BankAccountCreate />} />
-                    <Route path="edit/:id" element={<BankAccountEdit />} />
-                    <Route path="show/:id" element={<BankAccountShow />} />
-                  </Route>
-
-                  <Route path="tags">
-                    <Route index element={<TagList />} />
-                    <Route path="create" element={<TagCreate />} />
-                    <Route path="edit/:id" element={<TagEdit />} />
-                    <Route path="show/:id" element={<TagShow />} />
-                  </Route>
-
-                  <Route path="budgets">
-                    <Route index element={<BudgetList />} />
-                    <Route path="create" element={<BudgetCreate />} />
-                    <Route path="edit/:id" element={<BudgetEdit />} />
-                    <Route path="show/:id" element={<BudgetShow />} />
-                  </Route>
-
-                  <Route path="settings" element={<SettingsPage />} />
-                </Route>
-
-                <Route
-                  element={
-                    <Authenticated
-                      key="auth-pages"
-                      fallback={
-                        <>
-                          <EnvironmentBanner />
-                          <Outlet />
-                        </>
+                  <Route
+                    element={
+                      <Authenticated
+                        key="auth-pages"
+                        fallback={
+                          <>
+                            <EnvironmentBanner />
+                            <Outlet />
+                          </>
+                        }
+                      >
+                        <NavigateToResource />
+                      </Authenticated>
+                    }
+                  >
+                    <Route
+                      path="/login"
+                      element={
+                        <AuthPage type="login" title={<ProjectTitle />} />
                       }
-                    >
-                      <NavigateToResource />
-                    </Authenticated>
-                  }
-                >
+                    />
+                    <Route
+                      path="/register"
+                      element={
+                        <AuthPage type="register" title={<ProjectTitle />} />
+                      }
+                    />
+                    <Route
+                      path="/forgot-password"
+                      element={
+                        <AuthPage
+                          type="forgotPassword"
+                          title={<ProjectTitle />}
+                        />
+                      }
+                    />
+                    <Route
+                      path="/update-password"
+                      element={
+                        <AuthPage
+                          type="updatePassword"
+                          title={<ProjectTitle />}
+                        />
+                      }
+                    />
+                  </Route>
                   <Route
-                    path="/login"
-                    element={<AuthPage type="login" title={<ProjectTitle />} />}
-                  />
-                  <Route
-                    path="/register"
                     element={
-                      <AuthPage type="register" title={<ProjectTitle />} />
+                      <Authenticated key="catch-all">
+                        <ThemedLayout>
+                          <Outlet />
+                        </ThemedLayout>
+                      </Authenticated>
                     }
-                  />
-                  <Route
-                    path="/forgot-password"
-                    element={
-                      <AuthPage
-                        type="forgotPassword"
-                        title={<ProjectTitle />}
-                      />
-                    }
-                  />
-                  <Route
-                    path="/update-password"
-                    element={
-                      <AuthPage
-                        type="updatePassword"
-                        title={<ProjectTitle />}
-                      />
-                    }
-                  />
-                </Route>
-                <Route
-                  element={
-                    <Authenticated key="catch-all">
-                      <ThemedLayout>
-                        <Outlet />
-                      </ThemedLayout>
-                    </Authenticated>
-                  }
-                >
-                  <Route path="*" element={<ErrorComponent />} />
-                </Route>
-              </Routes>
-              <RefineKbar />
-              <UnsavedChangesNotifier />
-              <DocumentTitleHandler />
-            </Refine>
-          </AntdApp>
+                  >
+                    <Route path="*" element={<ErrorComponent />} />
+                  </Route>
+                </Routes>
+                <RefineKbar />
+                <UnsavedChangesNotifier />
+                <DocumentTitleHandler />
+              </Refine>
+            </AntdApp>
           </CurrencyContextProvider>
         </ColorModeContextProvider>
       </RefineKbarProvider>

--- a/apps/web-next/src/contexts/currency/index.tsx
+++ b/apps/web-next/src/contexts/currency/index.tsx
@@ -31,9 +31,7 @@ export const CurrencyContext = createContext<CurrencyContextType>({
 
 export const CurrencyContextProvider = ({ children }: PropsWithChildren) => {
   const [currency, setCurrencyState] = useState<string>(() => {
-    return (
-      localStorage.getItem(CURRENCY_STORAGE_KEY) ?? DEFAULT_CURRENCY
-    );
+    return localStorage.getItem(CURRENCY_STORAGE_KEY) ?? DEFAULT_CURRENCY;
   });
 
   useEffect(() => {

--- a/apps/web-next/src/pages/dashboard/index.tsx
+++ b/apps/web-next/src/pages/dashboard/index.tsx
@@ -208,7 +208,9 @@ const usePeriodStats = ({
     typeSummary: [],
     categorySummary: [],
   });
-  const [previousTypeSummary, setPreviousTypeSummary] = useState<TypeSummary[] | null>(null);
+  const [previousTypeSummary, setPreviousTypeSummary] = useState<
+    TypeSummary[] | null
+  >(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -343,7 +345,10 @@ const TypeSummaryCards = ({
                 value={current}
                 precision={2}
                 formatter={(value) =>
-                  formatCurrencyLocal(typeof value === "number" ? value : 0, currency)
+                  formatCurrencyLocal(
+                    typeof value === "number" ? value : 0,
+                    currency
+                  )
                 }
                 loading={loading}
                 valueStyle={{ color: TYPE_COLORS[type] }}
@@ -362,10 +367,20 @@ const TypeSummaryCards = ({
             value={netIncome}
             precision={2}
             formatter={(value) =>
-              formatCurrencyLocal(typeof value === "number" ? value : 0, currency)
+              formatCurrencyLocal(
+                typeof value === "number" ? value : 0,
+                currency
+              )
             }
             loading={loading}
-            valueStyle={{ color: netIncome > 0 ? "#52c41a" : netIncome < 0 ? "#ff4d4f" : undefined }}
+            valueStyle={{
+              color:
+                netIncome > 0
+                  ? "#52c41a"
+                  : netIncome < 0
+                    ? "#ff4d4f"
+                    : undefined,
+            }}
           />
           {!loading && previousData !== null && (
             <TrendBadge current={netIncome} previous={prevNetIncome} />

--- a/apps/web-next/src/pages/settings/index.tsx
+++ b/apps/web-next/src/pages/settings/index.tsx
@@ -21,10 +21,7 @@ import {
 import type { UploadFile, UploadProps } from "antd/es/upload/interface";
 import { supabaseClient } from "../../utility";
 import { Show } from "@refinedev/antd";
-import {
-  useCurrency,
-  SUPPORTED_CURRENCIES,
-} from "../../contexts/currency";
+import { useCurrency, SUPPORTED_CURRENCIES } from "../../contexts/currency";
 
 const { Paragraph } = Typography;
 

--- a/apps/web-next/src/pages/transactions/list.tsx
+++ b/apps/web-next/src/pages/transactions/list.tsx
@@ -10,41 +10,15 @@ import {
   TagField,
   FilterDropdown,
   getDefaultFilter,
-  type MapValueEvent,
 } from "@refinedev/antd";
 import { Table, Space, Segmented, Select, DatePicker, InputNumber } from "antd";
-import { useState, type Key } from "react";
+import { useState } from "react";
 import dayjs from "dayjs";
 import {
   TRANSACTION_TYPE_LABELS,
   TRANSACTION_TYPES,
 } from "../../constants/transactionTypes";
 import { formatAmount } from "../../utility";
-
-/**
- * Custom date range filter mapper that outputs date-only strings (YYYY-MM-DD)
- * instead of ISO timestamps to avoid timezone conversion issues.
- * Use this for DATE columns (not TIMESTAMP) in the database.
- */
-const dateOnlyFilterMapper = (selectedKeys: Key[], event: MapValueEvent) => {
-  if (!selectedKeys || selectedKeys.length === 0) {
-    return selectedKeys;
-  }
-
-  if (event === "value") {
-    return selectedKeys.map((key) =>
-      typeof key === "string" ? dayjs(key) : key
-    );
-  }
-
-  if (event === "onChange" && selectedKeys.every(dayjs.isDayjs)) {
-    return selectedKeys.map((date) =>
-      (date as unknown as dayjs.Dayjs).format("YYYY-MM-DD")
-    );
-  }
-
-  return selectedKeys;
-};
 
 const commonSelectOptions = {
   sorters: [{ field: "name", order: "asc" as const }],
@@ -80,7 +54,7 @@ export const TransactionList = () => {
     TRANSACTION_TYPES.SPEND
   );
 
-  const { tableProps, filters } = useTable({
+  const { tableProps, filters, setFilters } = useTable({
     syncWithLocation: true,
     resource: "transactions_with_details",
     sorters: {
@@ -142,12 +116,39 @@ export const TransactionList = () => {
           title="Date"
           sorter
           render={(value: string) => <DateField value={value} />}
-          filterDropdown={(props) => (
-            <FilterDropdown {...props} mapValue={dateOnlyFilterMapper}>
-              <DatePicker.RangePicker />
-            </FilterDropdown>
-          )}
-          defaultFilteredValue={getDefaultFilter("date", filters, "between")}
+          filterDropdown={({ confirm, clearFilters, close }) => {
+            const defaultVal = getDefaultFilter("date", filters, "between");
+            const defaultDates =
+              Array.isArray(defaultVal) && defaultVal.length === 2
+                ? ([dayjs(defaultVal[0] as string), dayjs(defaultVal[1] as string)] as [dayjs.Dayjs, dayjs.Dayjs])
+                : undefined;
+            return (
+              <div style={{ padding: 8 }}>
+                <DatePicker.RangePicker
+                  defaultValue={defaultDates}
+                  onChange={(dates) => {
+                    if (dates && dates[0] && dates[1]) {
+                      setFilters([
+                        {
+                          field: "date",
+                          operator: "between",
+                          value: [
+                            dates[0].format("YYYY-MM-DD"),
+                            dates[1].format("YYYY-MM-DD"),
+                          ],
+                        },
+                      ]);
+                      confirm({ closeDropdown: true });
+                    } else {
+                      if (clearFilters) clearFilters();
+                      setFilters([{ field: "date", operator: "between", value: undefined }]);
+                      close();
+                    }
+                  }}
+                />
+              </div>
+            );
+          }}
         />
         <Table.Column
           key="category_id"

--- a/apps/web-next/src/pages/transactions/list.tsx
+++ b/apps/web-next/src/pages/transactions/list.tsx
@@ -121,20 +121,29 @@ export const TransactionList = () => {
             const activeVal = getDefaultFilter("date", filters, "between");
             const value =
               Array.isArray(activeVal) && activeVal.length === 2
-                ? ([dayjs(activeVal[0] as string), dayjs(activeVal[1] as string)] as [dayjs.Dayjs, dayjs.Dayjs])
+                ? ([
+                    dayjs(activeVal[0] as string),
+                    dayjs(activeVal[1] as string),
+                  ] as [dayjs.Dayjs, dayjs.Dayjs])
                 : undefined;
             return (
               <div style={{ padding: 8 }}>
                 <DatePicker.RangePicker
                   value={value}
                   onChange={(dates) => {
-                    setFilters([{
-                      field: "date",
-                      operator: "between",
-                      value: dates?.[0] && dates?.[1]
-                        ? [dates[0].format("YYYY-MM-DD"), dates[1].format("YYYY-MM-DD")]
-                        : undefined,
-                    }]);
+                    setFilters([
+                      {
+                        field: "date",
+                        operator: "between",
+                        value:
+                          dates?.[0] && dates?.[1]
+                            ? [
+                                dates[0].format("YYYY-MM-DD"),
+                                dates[1].format("YYYY-MM-DD"),
+                              ]
+                            : undefined,
+                      },
+                    ]);
                     confirm({ closeDropdown: true });
                   }}
                 />

--- a/apps/web-next/src/pages/transactions/list.tsx
+++ b/apps/web-next/src/pages/transactions/list.tsx
@@ -116,34 +116,26 @@ export const TransactionList = () => {
           title="Date"
           sorter
           render={(value: string) => <DateField value={value} />}
-          filterDropdown={({ confirm, clearFilters, close }) => {
-            const defaultVal = getDefaultFilter("date", filters, "between");
-            const defaultDates =
-              Array.isArray(defaultVal) && defaultVal.length === 2
-                ? ([dayjs(defaultVal[0] as string), dayjs(defaultVal[1] as string)] as [dayjs.Dayjs, dayjs.Dayjs])
+          filteredValue={getDefaultFilter("date", filters, "between") ?? null}
+          filterDropdown={({ confirm }) => {
+            const activeVal = getDefaultFilter("date", filters, "between");
+            const value =
+              Array.isArray(activeVal) && activeVal.length === 2
+                ? ([dayjs(activeVal[0] as string), dayjs(activeVal[1] as string)] as [dayjs.Dayjs, dayjs.Dayjs])
                 : undefined;
             return (
               <div style={{ padding: 8 }}>
                 <DatePicker.RangePicker
-                  defaultValue={defaultDates}
+                  value={value}
                   onChange={(dates) => {
-                    if (dates && dates[0] && dates[1]) {
-                      setFilters([
-                        {
-                          field: "date",
-                          operator: "between",
-                          value: [
-                            dates[0].format("YYYY-MM-DD"),
-                            dates[1].format("YYYY-MM-DD"),
-                          ],
-                        },
-                      ]);
-                      confirm({ closeDropdown: true });
-                    } else {
-                      if (clearFilters) clearFilters();
-                      setFilters([{ field: "date", operator: "between", value: undefined }]);
-                      close();
-                    }
+                    setFilters([{
+                      field: "date",
+                      operator: "between",
+                      value: dates?.[0] && dates?.[1]
+                        ? [dates[0].format("YYYY-MM-DD"), dates[1].format("YYYY-MM-DD")]
+                        : undefined,
+                    }]);
+                    confirm({ closeDropdown: true });
                   }}
                 />
               </div>


### PR DESCRIPTION
## Why

The Date column filter on the Transactions page was silently broken for date-range queries. Refine's `FilterDropdown` component defaults to the `in` operator when an array of values is present. This meant that selecting a range like Jan 1 → Dec 31 produced a URL like `?filters[0][operator]=in&filters[0][value][]=2024-01-01&filters[0][value][]=2024-12-31`, which the backend interpreted as "return rows where date IS IN (Jan 1, Dec 31)". Only transactions landing on exactly those two boundary dates were returned; everything in between was silently excluded.

## What Changed

- **`apps/web-next/src/pages/transactions/list.tsx`**
  - Replaced the `FilterDropdown` + `mapValue={dateOnlyFilterMapper}` wrapper on the Date column with a custom `filterDropdown` render prop.
  - The custom dropdown calls `setFilters()` directly with `operator: "between"`, ensuring the correct operator is always sent regardless of Refine's default inference.
  - Removed the now-unused `dateOnlyFilterMapper` helper function (and its associated `MapValueEvent` type import) and the unused `Key` type import.
  - Destructures `setFilters` from `useTable` to support the direct filter update.

## Key Decisions

- **Custom `filterDropdown` instead of patching `FilterDropdown`:** Refine's `FilterDropdown` has no first-class prop to override the operator; the only public escape hatch is `mapValue`, which is intended for value transformation, not operator override. Using a custom dropdown with a direct `setFilters` call is the idiomatic Refine pattern for operator-specific filters and avoids monkey-patching internal logic.
- **Date-only strings (`YYYY-MM-DD`) preserved:** The previous `dateOnlyFilterMapper` existed to strip ISO timestamps down to date strings to avoid timezone drift on a DATE (not TIMESTAMP) column. The replacement implementation keeps this behaviour by calling `.format("YYYY-MM-DD")` directly inside the `onChange` handler.
- **`defaultValue` for URL hydration:** The custom picker reads `getDefaultFilter("date", filters, "between")` and converts the stored strings back to `dayjs` objects so that a page reload (with filters already in the URL) pre-populates the picker correctly.

## How This Affects the System

- **User-facing changes:** Date range filtering on the Transactions page now returns all transactions within the selected range, not just those on the exact boundary dates. The clear/reset path (selecting no dates) correctly removes the filter.
- **API changes:** The query operator changes from `in` → `between` for date filters. Any downstream query adapter must support `between`; Refine's Supabase adapter already does.
- **Performance implications:** None — the `between` operator maps to a SQL `BETWEEN` clause, which is at least as efficient as the previously generated `IN` clause.
- **Database changes:** None.
- **Breaking changes:** None — this is a bug fix restoring intended behaviour.

## Testing

- **New tests added:** None — this page does not yet have dedicated unit tests.
- **Existing tests status:** No existing tests target this filter; CI passes.
- **Manual testing performed:**
  - Selected a date range (e.g., 2024-01-01 → 2024-12-31) and verified the URL contains `operator=between` and that the full range of transactions is returned.
  - Cleared the date filter and verified no date filter appears in the URL and all transactions are shown.
  - Reloaded the page with a date filter already in the URL and confirmed the RangePicker is pre-populated with the correct dates.
- **Edge cases tested:**
  - Single-day range (start === end) — works correctly as a boundary-inclusive `between`.
  - Partial selection (one date chosen, other not yet selected) — filter is not applied until both dates are present.
- **Test files modified or added:** None.