### PR TITLE
chore(agents): enforce no direct commits to main or release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,12 @@
 
 This file provides guidance to AI agents when working with code in this repository.
 
+## ⚠️ Git Workflow — CRITICAL RULES
+
+- **NEVER commit directly to `main` or `release` branches.** Always create a feature branch for any code changes.
+- Only commit to `main` or `release` if the user explicitly instructs you to do so in that message.
+- Default workflow: create a branch → commit → open a PR.
+
 ## Repository Structure
 
 ```


### PR DESCRIPTION
## Why

Agents were committing directly to `main`, which bypasses PR review and risks polluting the branch history. This adds an explicit, prominently placed rule to prevent it.

## What Changed

- Files or areas updated: `AGENTS.md`
- New functionality added: ⚠️ Git Workflow — CRITICAL RULES section at the top
- Existing behavior changed: agents are now explicitly instructed never to commit to `main` or `release` unless the user says so directly in the message

## Key Decisions

- Decision: placed the rule at the very top of AGENTS.md before any other content
- Reasoning: agents read top-down; positioning it first maximises visibility
- Alternatives considered: adding it to a Deployment section — rejected because it would be easy to miss

## How This Affects the System

- User-facing changes: none
- API changes: none
- Performance implications: none
- Database changes: none
- Breaking changes: none

## Testing

- New tests added: N/A (docs change)
- Existing tests status: unaffected
- Manual testing performed: confirmed AGENTS.md renders correctly