### PR TITLE
perf(db): add partial indexes on transactions(user_id, date) for analytics queries

### DIFF
--- a/supabase/migrations/20260425000000_add_transaction_date_indexes.sql
+++ b/supabase/migrations/20260425000000_add_transaction_date_indexes.sql
@@ -1,0 +1,10 @@
+-- Composite index covering the most common analytics access pattern:
+-- filter by user + soft-delete, order/range by date
+CREATE INDEX IF NOT EXISTS idx_transactions_user_date
+    ON public.transactions (user_id, date DESC)
+    WHERE deleted_at IS NULL;
+
+-- Separate composite for type-filtered queries (view_monthly_totals, etc.)
+CREATE INDEX IF NOT EXISTS idx_transactions_user_type_date
+    ON public.transactions (user_id, type, date DESC)
+    WHERE deleted_at IS NULL;


### PR DESCRIPTION
## Why

The baseline migration creates no index on `transactions.date` or the composite `(user_id, date)`. Every analytics view (`view_monthly_totals`, `view_monthly_category_totals`, `view_monthly_tagged_type_totals`, etc.) performs `DATE_TRUNC('month', date)` range scans scoped to a user and a time window. Without an index these are sequential scans — O(n) per query, and the dashboard issues up to six such queries on mount.

Implements improvement 1.1 from `docs/superpowers/specs/2026-04-18-backend-db-plan.md`.

## What Changed

- Files or areas updated: `supabase/migrations/20260425000000_add_transaction_date_indexes.sql`
- New functionality added: two partial indexes on `public.transactions`
  - `idx_transactions_user_date` — `(user_id, date DESC) WHERE deleted_at IS NULL`
  - `idx_transactions_user_type_date` — `(user_id, type, date DESC) WHERE deleted_at IS NULL`
- Existing behavior changed: none — additive DDL only

## Key Decisions

- Decision: partial indexes with `WHERE deleted_at IS NULL`
- Reasoning: keeps indexes compact (only live rows), and the planner can satisfy the soft-delete predicate directly without a separate filter step
- Alternatives considered: full indexes — rejected as they'd include deleted rows unnecessarily

## How This Affects the System

- User-facing changes: faster dashboard load, especially as transaction count grows
- API changes: none
- Performance implications: positive — eliminates sequential scans on date-range analytics queries
- Database changes: two new partial indexes on `transactions`
- Breaking changes: none

## Testing

- New tests added: N/A — index creation is structural, not behavioural
- Existing tests status: 141/143 pass (2 pre-existing failures in `bank_accounts_usage_and_rpc_test.sql` confirmed on `main` before this change)
- Manual testing performed: `supabase db reset` applied migration cleanly; indexes verified via `\di idx_transactions_user*`