### PR TITLE
fix(db): use RETURN NEXT in delete_bank_account_safe and delete_tag_safe

### DIFF
--- a/supabase/migrations/20260425000001_fix_delete_safe_return_next.sql
+++ b/supabase/migrations/20260425000001_fix_delete_safe_return_next.sql
@@ -1,0 +1,90 @@
+-- Fix delete_bank_account_safe and delete_tag_safe: bare RETURN in a RETURNS TABLE
+-- function exits without emitting a row. Replace with RETURN NEXT to actually
+-- output the result row before exiting.
+
+CREATE OR REPLACE FUNCTION public.delete_bank_account_safe(p_bank_account_id uuid)
+  RETURNS TABLE(ok boolean, in_use_count bigint)
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = ''
+AS $$
+DECLARE
+  v_uid uuid;
+BEGIN
+  v_uid := auth.uid();
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated' USING ERRCODE = '28000';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.bank_accounts b
+    WHERE b.id = p_bank_account_id AND b.user_id = v_uid AND b.deleted_at IS NULL
+  ) THEN
+    RAISE EXCEPTION 'Bank account not found' USING ERRCODE = 'P0002';
+  END IF;
+
+  SELECT COUNT(*) INTO in_use_count
+  FROM public.transactions t
+  WHERE t.bank_account_id = p_bank_account_id
+    AND t.user_id = v_uid
+    AND t.deleted_at IS NULL;
+
+  IF in_use_count > 0 THEN
+    ok := false;
+    RETURN NEXT;
+    RETURN;
+  END IF;
+
+  UPDATE public.bank_accounts
+  SET deleted_at = NOW()
+  WHERE id = p_bank_account_id AND user_id = v_uid;
+
+  ok := true;
+  in_use_count := 0;
+  RETURN NEXT;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.delete_tag_safe(p_tag_id uuid)
+  RETURNS TABLE(ok boolean, in_use_count bigint)
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = ''
+AS $$
+DECLARE
+  v_uid uuid;
+BEGIN
+  v_uid := auth.uid();
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated' USING ERRCODE = '28000';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.tags g
+    WHERE g.id = p_tag_id AND g.user_id = v_uid AND g.deleted_at IS NULL
+  ) THEN
+    RAISE EXCEPTION 'Tag not found' USING ERRCODE = 'P0002';
+  END IF;
+
+  SELECT COUNT(*) INTO in_use_count
+  FROM public.transaction_tags tt
+  JOIN public.transactions t ON tt.transaction_id = t.id
+  WHERE tt.tag_id = p_tag_id
+    AND t.user_id = v_uid
+    AND t.deleted_at IS NULL;
+
+  IF in_use_count > 0 THEN
+    ok := false;
+    RETURN NEXT;
+    RETURN;
+  END IF;
+
+  UPDATE public.tags
+  SET deleted_at = NOW()
+  WHERE id = p_tag_id AND user_id = v_uid;
+
+  ok := true;
+  in_use_count := 0;
+  RETURN NEXT;
+END;
+$$;


### PR DESCRIPTION
## Why

`delete_bank_account_safe` and `delete_tag_safe` both use bare `RETURN` inside `RETURNS TABLE` functions. In PL/pgSQL, bare `RETURN` exits the function without emitting a row — so callers always received `NULL` instead of the expected `(ok, in_use_count)` result. This caused `bank_accounts_usage_and_rpc_test.sql` tests 2 and 3 to fail on every run.

## What Changed

- Files or areas updated: `supabase/migrations/20260425000001_fix_delete_safe_return_next.sql`
- New functionality added: none
- Existing behavior changed: both functions now correctly return a row — `RETURN` replaced with `RETURN NEXT` (emit row) followed by `RETURN` (exit) in the in-use branch, and `RETURN NEXT` at the success path

## Key Decisions

- Decision: fix via a new `CREATE OR REPLACE FUNCTION` migration rather than editing the original migration
- Reasoning: preserves migration history; safe to apply idempotently
- Alternatives considered: editing the original migration — rejected as it would break reproducibility for anyone who has already applied it

## How This Affects the System

- User-facing changes: deleting a bank account or tag now returns the correct response; previously the UI would have received a null/empty result
- API changes: none (same function signatures)
- Performance implications: none
- Database changes: two functions redefined via `CREATE OR REPLACE`
- Breaking changes: none

## Testing

- New tests added: none (pre-existing tests now pass)
- Existing tests status: **143/143 pass** (was 141/143 before this fix)
- Manual testing performed: `supabase db reset` + `supabase test db` — all green