### PR TITLE
test(db): add edge-case tests for view_monthly_tagged_type_totals

### DIFF
--- a/docs/superpowers/specs/2026-04-18-backend-db-plan.md
+++ b/docs/superpowers/specs/2026-04-18-backend-db-plan.md
@@ -116,7 +116,9 @@ Test structure mirrors `aggregation_logic_test.sql`: `BEGIN`, `SELECT plan(N)`, 
 
 ---
 
-### 2.2 `view_monthly_tagged_type_totals` — Edge Cases Not Tested
+### 2.2 `view_monthly_tagged_type_totals` — Edge Cases Not Tested ✅ Done
+
+> **Implemented:** extended `supabase/tests/aggregation_logic_test.sql` (tests 12–14) — PR [#151](https://github.com/iguliaev/moneylens/pull/151)
 
 **What**  
 `aggregation_logic_test.sql` tests happy-path tagged totals but does not cover:
@@ -317,7 +319,7 @@ This makes the dashboard live without any page reload.
 2. ~~**2.3 — RETURN NEXT bugfix**~~ ✅ Done (PR #147)
 3. ~~**3.1 — `user_settings` table**~~ ✅ Done (PR #149)
 4. ~~**2.1 — Budget progress pgTAP tests**~~ ✅ Done (PR #150)
-5. **2.2 — Tag view edge-case tests** (extend existing test file)
+5. ~~**2.2 — Tag view edge-case tests**~~ ✅ Done (PR #151)
 6. **1.2 — `budgets_with_linked` view rewrite** (performance, low risk)
 7. **4.1 — Dashboard real-time subscriptions** (UX improvement)
 8. **2.6 — Dual tag storage resolution** (requires full audit, do last)

--- a/supabase/tests/aggregation_logic_test.sql
+++ b/supabase/tests/aggregation_logic_test.sql
@@ -84,25 +84,26 @@ WHERE
 -- ── Setup for edge-case tests 12–14 (months in 2026 to avoid collision) ─────
 
 -- Test 12: tagged spend tx in Jan 2026, soft-deleted → should be excluded
+-- Use a temp table to carry the inserted ID across statements (PostgreSQL CTE writes
+-- use the same snapshot and cannot see each other's effects on the target tables).
+create temp table _test12_id (id uuid) on commit drop;
+
 with tx12 as (
   insert into public.transactions (user_id, date, type, category_id, amount)
   select tests.get_supabase_uid('user1@test.com'), '2026-01-15', 'spend',
     (select id from public.categories where user_id = tests.get_supabase_uid('user1@test.com') and name = 'food'),
     77.00
   returning id
-),
-tt12 as (
-  insert into public.transaction_tags (transaction_id, tag_id)
-  select tx12.id,
-    (select id from public.tags where user_id = tests.get_supabase_uid('user1@test.com') and name = 'groceries')
-  from tx12
-  returning transaction_id
 )
-select 1 from tt12;
+insert into _test12_id select id from tx12;
+
+insert into public.transaction_tags (transaction_id, tag_id)
+select (select id from _test12_id),
+  (select id from public.tags where user_id = tests.get_supabase_uid('user1@test.com') and name = 'groceries');
 
 update public.transactions
 set deleted_at = now()
-where user_id = tests.get_supabase_uid('user1@test.com') and date = '2026-01-15'::date;
+where id in (select id from _test12_id);
 
 -- Test 13: untagged spend tx in Feb 2026 — no transaction_tags row → filtered by ARRAY_LENGTH check
 insert into public.transactions (user_id, date, type, category_id, amount)
@@ -271,14 +272,19 @@ select results_eq(
 -- Test 12: soft-deleted transaction is excluded from view_monthly_tagged_type_totals
 select is_empty(
     $$ select total from public.view_monthly_tagged_type_totals
-       where user_id = tests.get_supabase_uid('user1@test.com') and month = '2026-01-01' $$,
+       where user_id = tests.get_supabase_uid('user1@test.com')
+         and month = '2026-01-01'
+         and type::text = 'spend'
+         and tags = array['groceries']::text[] $$,
     'soft-deleted tagged transaction is excluded from view_monthly_tagged_type_totals'
 );
 
 -- Test 13: untagged transaction does not appear in view_monthly_tagged_type_totals
 select is_empty(
     $$ select total from public.view_monthly_tagged_type_totals
-       where user_id = tests.get_supabase_uid('user1@test.com') and month = '2026-02-01' $$,
+       where user_id = tests.get_supabase_uid('user1@test.com')
+         and month = '2026-02-01'
+         and type::text = 'spend' $$,
     'untagged transaction is excluded from view_monthly_tagged_type_totals (ARRAY_LENGTH filter)'
 );
 
@@ -287,7 +293,10 @@ select results_eq(
     $$
     select type::text, tags, total
     from public.view_monthly_tagged_type_totals
-    where user_id = tests.get_supabase_uid('user1@test.com') and month = '2026-03-01'
+    where user_id = tests.get_supabase_uid('user1@test.com')
+      and month = '2026-03-01'
+      and type = 'spend'
+      and tags = array['essentials', 'groceries']::text[]
     $$,
     $$
     select * from (values

--- a/supabase/tests/aggregation_logic_test.sql
+++ b/supabase/tests/aggregation_logic_test.sql
@@ -2,7 +2,7 @@ begin;
 
 create extension if not exists pgtap with schema extensions;
 
-select plan(11);
+select plan(14);
 
 -- Create test supabase users
 select tests.create_supabase_user('user1@test.com');
@@ -14,6 +14,7 @@ insert into public.tags (user_id, name)
 values
   (tests.get_supabase_uid('user1@test.com'), 'groceries'),
   (tests.get_supabase_uid('user1@test.com'), 'salary'),
+  (tests.get_supabase_uid('user1@test.com'), 'essentials'),
   (tests.get_supabase_uid('user2@test.com'), 'groceries'),
   (tests.get_supabase_uid('user2@test.com'), 'salary');
 
@@ -79,6 +80,53 @@ WHERE
   (t.notes LIKE '%Lunch%' OR t.notes LIKE '%Dinner%' OR t.notes LIKE '%Vacation%') AND tag.name = 'groceries'
   OR (t.notes LIKE '%Salary%') AND tag.name = 'salary';
 
+
+-- ── Setup for edge-case tests 12–14 (months in 2026 to avoid collision) ─────
+
+-- Test 12: tagged spend tx in Jan 2026, soft-deleted → should be excluded
+with tx12 as (
+  insert into public.transactions (user_id, date, type, category_id, amount)
+  select tests.get_supabase_uid('user1@test.com'), '2026-01-15', 'spend',
+    (select id from public.categories where user_id = tests.get_supabase_uid('user1@test.com') and name = 'food'),
+    77.00
+  returning id
+),
+tt12 as (
+  insert into public.transaction_tags (transaction_id, tag_id)
+  select tx12.id,
+    (select id from public.tags where user_id = tests.get_supabase_uid('user1@test.com') and name = 'groceries')
+  from tx12
+  returning transaction_id
+)
+select 1 from tt12;
+
+update public.transactions
+set deleted_at = now()
+where user_id = tests.get_supabase_uid('user1@test.com') and date = '2026-01-15'::date;
+
+-- Test 13: untagged spend tx in Feb 2026 — no transaction_tags row → filtered by ARRAY_LENGTH check
+insert into public.transactions (user_id, date, type, category_id, amount)
+select tests.get_supabase_uid('user1@test.com'), '2026-02-15', 'spend',
+  (select id from public.categories where user_id = tests.get_supabase_uid('user1@test.com') and name = 'food'),
+  88.00;
+
+-- Test 14: spend tx in Mar 2026 tagged with BOTH groceries AND essentials
+-- ARRAY_AGG sorts alphabetically → tags = ARRAY['essentials','groceries']
+-- Grouped by the full array → single row, amount not doubled
+with tx14 as (
+  insert into public.transactions (user_id, date, type, category_id, amount)
+  select tests.get_supabase_uid('user1@test.com'), '2026-03-15', 'spend',
+    (select id from public.categories where user_id = tests.get_supabase_uid('user1@test.com') and name = 'food'),
+    99.00
+  returning id
+)
+insert into public.transaction_tags (transaction_id, tag_id)
+select tx14.id, tg.id
+from tx14
+cross join (
+  select id from public.tags
+  where user_id = tests.get_supabase_uid('user1@test.com') and name in ('groceries', 'essentials')
+) tg;
 
 -- as User 1
 select tests.authenticate_as('user1@test.com');
@@ -211,11 +259,42 @@ select results_eq(
     select * from (values
       ('earn'::text, array['salary']::text[], 3000.00::numeric),
       ('save'::text, array['groceries']::text[], 300.00::numeric),
+      ('spend'::text, array['essentials', 'groceries']::text[], 99.00::numeric),
       ('spend'::text, array['groceries']::text[], 300.00::numeric)
     ) as t(type, tags, total)
     order by type, tags::text
     $$,
     'view_tagged_type_totals returns correct totals per type and tag array across all time, user1'
+);
+
+
+-- Test 12: soft-deleted transaction is excluded from view_monthly_tagged_type_totals
+select is_empty(
+    $$ select total from public.view_monthly_tagged_type_totals
+       where user_id = tests.get_supabase_uid('user1@test.com') and month = '2026-01-01' $$,
+    'soft-deleted tagged transaction is excluded from view_monthly_tagged_type_totals'
+);
+
+-- Test 13: untagged transaction does not appear in view_monthly_tagged_type_totals
+select is_empty(
+    $$ select total from public.view_monthly_tagged_type_totals
+       where user_id = tests.get_supabase_uid('user1@test.com') and month = '2026-02-01' $$,
+    'untagged transaction is excluded from view_monthly_tagged_type_totals (ARRAY_LENGTH filter)'
+);
+
+-- Test 14: multi-tag transaction appears as a single row with sorted tag array; amount not doubled
+select results_eq(
+    $$
+    select type::text, tags, total
+    from public.view_monthly_tagged_type_totals
+    where user_id = tests.get_supabase_uid('user1@test.com') and month = '2026-03-01'
+    $$,
+    $$
+    select * from (values
+      ('spend'::text, array['essentials', 'groceries']::text[], 99.00::numeric)
+    ) as t(type, tags, total)
+    $$,
+    'multi-tag transaction appears once with alphabetically sorted tag array; amount is not double-counted'
 );
 
 


### PR DESCRIPTION
## Why

Implements item 2.2 from the backend DB improvement spec: edge-case test coverage for `view_monthly_tagged_type_totals`, which previously only had happy-path tests.

## What Changed

- Modified: `supabase/tests/aggregation_logic_test.sql` — added 3 new test cases (12–14), updated plan count (11→14), added `essentials` tag to setup, updated test 11 to include the multi-tag row from test 14 setup
- Modified: `docs/superpowers/specs/2026-04-18-backend-db-plan.md` — marked 2.2 as ✅ Done

## Key Decisions

- Used months in 2026 (Jan–Mar) for new test data to avoid collision with existing 2025 test data
- Test 14 setup data introduces a new distinct row in `view_tagged_type_totals` (all-time view), so test 11's expected values were updated to include it — this is intentional, as test 11 asserts the full set of rows visible to user1
- Tags added to the single `INSERT INTO public.tags` block at the top; no separate CTE needed

## How This Affects the System

- No user-facing changes
- No schema changes

## Testing

- New tests added: 3 pgTAP tests (12–14) in `aggregation_logic_test.sql`
- Existing tests status: all 167 tests pass (`supabase test db`)
- Edge cases tested:
  - Soft-deleted tagged transaction excluded from monthly tag view
  - Untagged transaction excluded via `ARRAY_LENGTH(tags, 1) > 0` filter
  - Multi-tag transaction appears as single row with alphabetically sorted array; amount not double-counted