### PR TITLE
chore: default dashboard to Monthly Statistics tab

### DIFF
--- a/apps/web-next/src/pages/dashboard/index.tsx
+++ b/apps/web-next/src/pages/dashboard/index.tsx
@@ -585,7 +585,7 @@ export const DashboardPage: FC = () => {
   return (
     <Show title="Dashboard" headerButtons={() => null}>
       <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
-        <Tabs items={tabItems} defaultActiveKey="yearly" />
+        <Tabs items={tabItems} defaultActiveKey="monthly" />
         <BudgetsSection />
       </div>
     </Show>

--- a/docs/superpowers/specs/2026-04-18-ux-interaction-plan.md
+++ b/docs/superpowers/specs/2026-04-18-ux-interaction-plan.md
@@ -4,7 +4,7 @@
 
 ---
 
-## 1. Dashboard: Default to "Monthly Statistics" Tab
+## 1. Dashboard: Default to "Monthly Statistics" Tab ✅ Done
 
 **Priority:** 🔴 High Impact / 🟢 Low Complexity — **Quick Win #1**
 

--- a/docs/superpowers/specs/2026-04-18-ux-interaction-plan.md
+++ b/docs/superpowers/specs/2026-04-18-ux-interaction-plan.md
@@ -4,7 +4,7 @@
 
 ---
 
-## 1. Dashboard: Default to "Monthly Statistics" Tab ✅ Done
+## 1. Dashboard: Default to "Monthly Statistics" Tab ✅ Done — [PR #154](https://github.com/iguliaev/moneylens/pull/154)
 
 **Priority:** 🔴 High Impact / 🟢 Low Complexity — **Quick Win #1**
 


### PR DESCRIPTION
## Why

Day-to-day app use is month-focused, but the dashboard was opening on the Yearly Statistics tab. This changes the default so users immediately see the current month's data on load.

## What Changed

- Files or areas updated: `apps/web-next/src/pages/dashboard/index.tsx`, `docs/superpowers/specs/2026-04-18-ux-interaction-plan.md`
- Existing behavior changed: Dashboard now opens on Monthly Statistics tab instead of Yearly

## Key Decisions

- Decision: Only change the `defaultActiveKey` prop
- Reasoning: `selectedMonth`/`selectedYear` state already defaults to the current month/year, so no further change needed
- Alternatives considered: None — minimal, targeted change

## How This Affects the System

- User-facing changes: Dashboard opens on Monthly Statistics tab instead of Yearly
- No API, DB, performance, or breaking changes

## Testing

- New tests added: None required for a one-prop change
- Manual testing performed: Verified tab loads with current month data