### PR TITLE
feat: add AppstoreOutlined icon to categories sidebar resource

### DIFF
--- a/apps/web-next/src/App.tsx
+++ b/apps/web-next/src/App.tsx
@@ -1,5 +1,6 @@
 import { Authenticated, Refine } from "@refinedev/core";
 import {
+  AppstoreOutlined,
   BankOutlined,
   DashboardOutlined,
   TagsOutlined,
@@ -140,6 +141,10 @@ function App() {
                     create: "/categories/create",
                     edit: "/categories/edit/:id",
                     show: "/categories/show/:id",
+                    meta: {
+                      label: "Categories",
+                      icon: <AppstoreOutlined />,
+                    },
                   },
                   {
                     name: "bank_accounts", // Database table name

--- a/docs/superpowers/specs/2026-04-18-ux-interaction-plan.md
+++ b/docs/superpowers/specs/2026-04-18-ux-interaction-plan.md
@@ -21,7 +21,7 @@ The app opens on "Monthly Statistics", scoped to the current month and year auto
 
 ---
 
-## 2. Categories Resource: Add Sidebar Icon
+## 2. Categories Resource: Add Sidebar Icon ✅ Done — [PR #155](https://github.com/iguliaev/moneylens/pull/155)
 
 **Priority:** 🔴 High Impact / 🟢 Low Complexity — **Quick Win #2**
 


### PR DESCRIPTION
## Why

The `categories` resource in `App.tsx` had no `meta.icon`, making it the only sidebar item rendered as plain text — visually inconsistent with all other menu items (Transactions, Budgets, Bank Accounts, Tags, etc.).

## What Changed

- Files or areas updated: `apps/web-next/src/App.tsx`
- New functionality added: `AppstoreOutlined` imported from `@ant-design/icons` and added as `meta.icon` on the categories resource, alongside an explicit `label: "Categories"`.
- Existing behavior changed: Categories sidebar entry now shows a grid/app icon.

## Key Decisions

- Decision: Use `AppstoreOutlined` as recommended in the UX interaction plan.
- Reasoning: Consistent with the plan's suggestion; the icon semantically represents a collection of categorised items.
- Alternatives considered: `UnorderedListOutlined` / `FolderOutlined` — both valid, but `AppstoreOutlined` was the first-listed recommendation.

## How This Affects the System

- User-facing changes: Categories sidebar menu item now displays an icon.
- API changes: None.
- Performance implications: None.
- Database changes: None.
- Breaking changes: None.

## Testing

- New tests added: None (cosmetic sidebar change).
- Existing tests status: TypeScript type-check passes (`npm run check-types`).
- Manual testing performed: Verified `App.tsx` compiles cleanly.
- Edge cases tested: N/A.
- Test files modified or added: None.