### PR TITLE
feat: register KBar quick-add transaction action

### DIFF
--- a/apps/web-next/src/components/header/index.tsx
+++ b/apps/web-next/src/components/header/index.tsx
@@ -10,6 +10,7 @@ import {
 } from "antd";
 import React, { useContext } from "react";
 import { ColorModeContext } from "../../contexts/color-mode";
+import { useQuickActions } from "../../hooks/useQuickActions";
 
 const { Text } = Typography;
 const { useToken } = theme;
@@ -26,6 +27,7 @@ export const Header: React.FC<RefineThemedLayoutHeaderProps> = ({
   const { token } = useToken();
   const { data: user } = useGetIdentity<IUser>();
   const { mode, setMode } = useContext(ColorModeContext);
+  useQuickActions();
 
   const headerStyles: React.CSSProperties = {
     backgroundColor: token.colorBgElevated,

--- a/apps/web-next/src/hooks/useQuickActions.ts
+++ b/apps/web-next/src/hooks/useQuickActions.ts
@@ -1,0 +1,20 @@
+import { Priority, useRegisterActions } from "@refinedev/kbar";
+import { useNavigation } from "@refinedev/core";
+
+export const useQuickActions = () => {
+  const { create } = useNavigation();
+
+  useRegisterActions(
+    [
+      {
+        id: "add-transaction",
+        name: "Add Transaction",
+        keywords: "new transaction add spend earn save",
+        perform: () => create("transactions"),
+        section: "Quick Actions",
+        priority: Priority.HIGH,
+      },
+    ],
+    []
+  );
+};

--- a/docs/superpowers/specs/2026-04-18-ux-interaction-plan.md
+++ b/docs/superpowers/specs/2026-04-18-ux-interaction-plan.md
@@ -101,13 +101,7 @@ A search bar above the table filters across `notes` using `containsi`. Amount fi
 
 **Priority:** 🟡 Medium Impact / 🟢 Low Complexity — **Quick Win #4**
 
-### Current Experience
-`<RefineKbar>` is set up but no custom actions are registered — the palette only shows auto-generated navigation shortcuts.
-
-### Improved Experience
-Pressing Cmd+K and typing "add" shows an **"Add Transaction"** action that navigates to `/transactions/create`.
-
-### Implemented Experience
+### Experience
 Pressing Cmd+K and typing "add" shows an **"Add Transaction"** action that navigates to `/transactions/create`.
 
 ### Implementation Notes

--- a/docs/superpowers/specs/2026-04-18-ux-interaction-plan.md
+++ b/docs/superpowers/specs/2026-04-18-ux-interaction-plan.md
@@ -107,19 +107,13 @@ A search bar above the table filters across `notes` using `containsi`. Amount fi
 ### Improved Experience
 Pressing Cmd+K and typing "add" shows an **"Add Transaction"** action that navigates to `/transactions/create`.
 
-### How to Implement
-Create `src/hooks/useQuickActions.ts` using `useRegisterActions` from `@refinedev/kbar`:
-```ts
-useRegisterActions([{
-  id: "add-transaction",
-  name: "Add Transaction",
-  keywords: "new transaction add spend earn save",
-  perform: () => create("transactions"),
-  section: "Quick Actions",
-  priority: Priority.HIGH,
-}], []);
-```
-Call `useQuickActions()` inside the authenticated layout (e.g., in `Header`).
+### Implemented Experience
+Pressing Cmd+K and typing "add" shows an **"Add Transaction"** action that navigates to `/transactions/create`.
+
+### Implementation Notes
+- `src/hooks/useQuickActions.ts` — calls `useRegisterActions` from `@refinedev/kbar` with a single "Add Transaction" action (`Priority.HIGH`, section "Quick Actions", keywords `new transaction add spend earn save`)
+- `useNavigation().create("transactions")` navigates to the create page
+- `useQuickActions()` is called inside `Header` so it's always active in the authenticated layout
 
 ---
 


### PR DESCRIPTION
## Why

`<RefineKbar>` was set up but only showed auto-generated navigation shortcuts. This adds a custom "Add Transaction" action so power users can hit Cmd+K, type "add", and jump straight to the transaction create page without touching the mouse.

## What Changed

- Files or areas updated: `src/components/header/index.tsx`, `docs/superpowers/specs/2026-04-18-ux-interaction-plan.md`
- New functionality added: `src/hooks/useQuickActions.ts` — registers an "Add Transaction" KBar action with `Priority.HIGH`, section "Quick Actions", and keywords `new transaction add spend earn save`
- Existing behavior changed: `Header` now calls `useQuickActions()` on every render in the authenticated layout

## Key Decisions

- Decision: Call the hook in `Header` rather than a layout wrapper
- Reasoning: `Header` is already the authenticated shell component and always mounted; no new component needed
- Alternatives considered: Registering in `App.tsx` directly, but that couples app config to action logic

## How This Affects the System

- User-facing changes: Cmd+K → "add" → navigates to `/transactions/create`
- API changes: None
- Performance implications: None — `useRegisterActions` is a lightweight hook
- Database changes: None
- Breaking changes: None

## Testing

- New tests added: None (navigation action, covered by existing KBar setup)
- Existing tests status: Passing
- Manual testing performed: Opened KBar, typed "add", confirmed "Add Transaction" action appears and navigates correctly
- Edge cases tested: Action is scoped to authenticated layout only
- Test files modified or added: None