### PR TITLE
chore: mark KBar quick-add action as done in UX plan doc

### DIFF
--- a/docs/superpowers/specs/2026-04-18-ux-interaction-plan.md
+++ b/docs/superpowers/specs/2026-04-18-ux-interaction-plan.md
@@ -97,7 +97,7 @@ A search bar above the table filters across `notes` using `containsi`. Amount fi
 
 ---
 
-## 6. Register KBar Quick-Add Transaction Action
+## 6. Register KBar Quick-Add Transaction Action ✅ Done — [PR #157](https://github.com/iguliaev/moneylens/pull/157)
 
 **Priority:** 🟡 Medium Impact / 🟢 Low Complexity — **Quick Win #4**
 


### PR DESCRIPTION
## Why

The doc commit marking section 6 as ✅ Done (with PR #157 link) was pushed to the feature branch after the PR was already merged, so it didn't land in main.

## What Changed

- Files or areas updated: `docs/superpowers/specs/2026-04-18-ux-interaction-plan.md`
- Existing behavior changed: Section 6 heading now reads `✅ Done — [PR #157]` to match the pattern used in sections 1 & 2