### PR TITLE
feat(transactions): replace Loading text with skeleton on show page

### DIFF
--- a/apps/web-next/src/pages/transactions/show.tsx
+++ b/apps/web-next/src/pages/transactions/show.tsx
@@ -1,13 +1,15 @@
 import { useShow, useOne } from "@refinedev/core";
 import { Show, TextField, DateField } from "@refinedev/antd";
-import { Typography } from "antd";
+import { Typography, Skeleton } from "antd";
 import { formatCurrency } from "../../utility";
+import { useCurrency } from "../../contexts/currency";
 
 const { Title } = Typography;
 
 export const TransactionShow = () => {
   const { query, result: record } = useShow();
   const { isLoading } = query;
+  const { currency } = useCurrency();
 
   const categoryQuery = useOne({
     resource: "categories",
@@ -36,11 +38,19 @@ export const TransactionShow = () => {
       <Title level={5}>Type</Title>
       <TextField value={record?.type} />
       <Title level={5}>Category</Title>
-      {categoryIsLoading ? <>Loading...</> : <>{categoryData?.name}</>}
+      {categoryIsLoading ? (
+        <Skeleton.Input active size="small" style={{ width: 120 }} />
+      ) : (
+        <>{categoryData?.name}</>
+      )}
       <Title level={5}>Amount</Title>
-      <TextField value={formatCurrency(record?.amount ?? 0, "GBP")} />
+      <TextField value={formatCurrency(record?.amount ?? 0, currency)} />
       <Title level={5}>Bank Account</Title>
-      {bankAccountIsLoading ? <>Loading...</> : <>{bankAccountData?.name}</>}
+      {bankAccountIsLoading ? (
+        <Skeleton.Input active size="small" style={{ width: 120 }} />
+      ) : (
+        <>{bankAccountData?.name}</>
+      )}
       <Title level={5}>Notes</Title>
       <TextField value={record?.notes} />
     </Show>

--- a/docs/superpowers/specs/2026-04-18-ux-interaction-plan.md
+++ b/docs/superpowers/specs/2026-04-18-ux-interaction-plan.md
@@ -110,7 +110,7 @@ Pressing Cmd+K and typing "add" shows an **"Add Transaction"** action that navig
 
 ---
 
-## 7. Transaction Show Page: Replace "Loading…" with Skeleton ✅ Done
+## 7. Transaction Show Page: Replace "Loading…" with Skeleton ✅ Done — [PR #162](https://github.com/iguliaev/moneylens/pull/162)
 
 **Priority:** 🟡 Medium Impact / 🟢 Low Complexity — **Quick Win #5**
 

--- a/docs/superpowers/specs/2026-04-18-ux-interaction-plan.md
+++ b/docs/superpowers/specs/2026-04-18-ux-interaction-plan.md
@@ -110,7 +110,7 @@ Pressing Cmd+K and typing "add" shows an **"Add Transaction"** action that navig
 
 ---
 
-## 7. Transaction Show Page: Replace "Loading…" with Skeleton
+## 7. Transaction Show Page: Replace "Loading…" with Skeleton ✅ Done
 
 **Priority:** 🟡 Medium Impact / 🟢 Low Complexity — **Quick Win #5**
 


### PR DESCRIPTION
## Why

Improve the perceived performance of the Transaction Show page by replacing jarring "Loading..." text placeholders with animated skeleton loaders. Fixes the hardcoded "GBP" currency to use the user's configured currency.

Implements feature #7 from the UX Interaction Plan.

## What Changed

- Replace 'Loading...' text with `Skeleton.Input` components for category and bank account fields that load asynchronously
- Use `useCurrency()` hook instead of hardcoded 'GBP' for amount formatting
- Maintains stable layout during async data fetch, improving user experience

Files updated:
- `apps/web-next/src/pages/transactions/show.tsx`
- `docs/superpowers/specs/2026-04-18-ux-interaction-plan.md` (marked feature #7 complete)

## Key Decisions

- Used `style={{ width: 120 }}` on Skeleton.Input to match typical field widths for category and bank account names
- Kept existing loading state for the main record (`<Show isLoading>`) while adding skeleton loaders for related entities
- No changes to core logic, only UX improvements

## How This Affects the System

- User-facing changes: Smoother loading experience on transaction detail page with animated skeleton placeholders
- No API, database, or performance changes
- No breaking changes

## Testing

- TypeScript compilation verified (`npm run check-types`)
- No new tests required as this is a pure UI enhancement
- Existing tests continue to pass