### PR TITLE
feat: Add empty states with custom CTAs to all list pages

### DIFF
--- a/apps/web-next/e2e/tests/empty-states.spec.ts
+++ b/apps/web-next/e2e/tests/empty-states.spec.ts
@@ -1,0 +1,130 @@
+import { test, expect } from "@playwright/test";
+import {
+  createTestUser,
+  deleteTestUser,
+  loginUser,
+  cleanupReferenceDataForUser,
+  cleanupTransactionsForUser,
+} from "../utils/test-helpers";
+
+test.describe("Empty States", () => {
+  let testUser: { email: string; password: string; userId: string };
+
+  test.beforeAll(async () => {
+    // Create a fresh test user with NO seeded data
+    testUser = await createTestUser();
+  });
+
+  test.afterAll(async () => {
+    await deleteTestUser(testUser.userId);
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await loginUser(page, testUser.email, testUser.password);
+  });
+
+  test("Transactions list shows empty state with CTA", async ({ page }) => {
+    await page.goto("/transactions");
+
+    // Verify empty state title and description are visible
+    await expect(page.getByText("No Transactions Yet")).toBeVisible();
+    await expect(
+      page.getByText("Start tracking your finances by adding your first transaction.")
+    ).toBeVisible();
+
+    // Verify CTA button is visible and clickable
+    const addButton = page.getByRole("button", { name: "Add Transaction" });
+    await expect(addButton).toBeVisible();
+
+    // Click CTA and verify navigation to create page
+    await addButton.click();
+    await expect(page).toHaveURL(/\/transactions\/create/);
+    await expect(
+      page.getByRole("heading", { name: "Create Transaction" })
+    ).toBeVisible();
+  });
+
+  test("Budgets list shows empty state with CTA", async ({ page }) => {
+    await page.goto("/budgets");
+
+    // Verify empty state title and description are visible
+    await expect(page.getByText("No Budgets Yet")).toBeVisible();
+    await expect(
+      page.getByText("Create a budget to track your spending goals and stay on target.")
+    ).toBeVisible();
+
+    // Verify CTA button is visible and clickable
+    const createButton = page.getByRole("button", { name: "Create Budget" });
+    await expect(createButton).toBeVisible();
+
+    // Click CTA and verify navigation to create page
+    await createButton.click();
+    await expect(page).toHaveURL(/\/budgets\/create/);
+    await expect(
+      page.getByRole("heading", { name: "Create Budget" })
+    ).toBeVisible();
+  });
+
+  test("Categories list shows empty state with CTA", async ({ page }) => {
+    await page.goto("/categories");
+
+    // Verify empty state title and description are visible
+    await expect(page.getByText("No Categories Yet")).toBeVisible();
+    await expect(
+      page.getByText("Add categories to organize and track your transactions better.")
+    ).toBeVisible();
+
+    // Verify CTA button is visible and clickable
+    const addButton = page.getByRole("button", { name: "Add Category" });
+    await expect(addButton).toBeVisible();
+
+    // Click CTA and verify navigation to create page
+    await addButton.click();
+    await expect(page).toHaveURL(/\/categories\/create/);
+    await expect(
+      page.getByRole("heading", { name: "Create Category" })
+    ).toBeVisible();
+  });
+
+  test("Bank Accounts list shows empty state with CTA", async ({ page }) => {
+    await page.goto("/bank-accounts");
+
+    // Verify empty state title and description are visible
+    await expect(page.getByText("No Bank Accounts Yet")).toBeVisible();
+    await expect(
+      page.getByText("Link your bank accounts to start tracking all your transactions in one place.")
+    ).toBeVisible();
+
+    // Verify CTA button is visible and clickable
+    const addButton = page.getByRole("button", { name: "Add Bank Account" });
+    await expect(addButton).toBeVisible();
+
+    // Click CTA and verify navigation to create page
+    await addButton.click();
+    await expect(page).toHaveURL(/\/bank-accounts\/create/);
+    await expect(
+      page.getByRole("heading", { name: "Create Bank Account" })
+    ).toBeVisible();
+  });
+
+  test("Tags list shows empty state with CTA", async ({ page }) => {
+    await page.goto("/tags");
+
+    // Verify empty state title and description are visible
+    await expect(page.getByText("No Tags Yet")).toBeVisible();
+    await expect(
+      page.getByText("Create tags to label and filter your transactions by custom attributes.")
+    ).toBeVisible();
+
+    // Verify CTA button is visible and clickable
+    const addButton = page.getByRole("button", { name: "Add Tag" });
+    await expect(addButton).toBeVisible();
+
+    // Click CTA and verify navigation to create page
+    await addButton.click();
+    await expect(page).toHaveURL(/\/tags\/create/);
+    await expect(
+      page.getByRole("heading", { name: "Create Tag" })
+    ).toBeVisible();
+  });
+});

--- a/apps/web-next/src/components/EmptyState.tsx
+++ b/apps/web-next/src/components/EmptyState.tsx
@@ -1,0 +1,35 @@
+import { Empty, Button, Space } from "antd";
+import React from "react";
+
+interface EmptyStateProps {
+  title: string;
+  description: string;
+  actionLabel: string;
+  onAction: () => void;
+}
+
+/**
+ * Reusable empty state component for list pages.
+ * Displays a title, description, and CTA button.
+ */
+export const EmptyState: React.FC<EmptyStateProps> = ({
+  title,
+  description,
+  actionLabel,
+  onAction,
+}) => (
+  <Empty
+    style={{ marginTop: 48 }}
+    image={Empty.PRESENTED_IMAGE_SIMPLE}
+    description={
+      <Space direction="vertical" size="small">
+        <div style={{ fontWeight: 600, fontSize: 16 }}>{title}</div>
+        <div style={{ fontSize: 14, color: "#666" }}>{description}</div>
+      </Space>
+    }
+  >
+    <Button type="primary" onClick={onAction}>
+      {actionLabel}
+    </Button>
+  </Empty>
+);

--- a/apps/web-next/src/components/EmptyStates.tsx
+++ b/apps/web-next/src/components/EmptyStates.tsx
@@ -1,0 +1,68 @@
+import { useNavigation } from "@refinedev/core";
+import { EmptyState } from "./EmptyState";
+import React from "react";
+
+/**
+ * Empty state helpers for different resource types.
+ * Each helper returns a component configured with appropriate title, description, and navigation.
+ */
+
+export const getTransactionEmptyState = (): React.ReactNode => {
+  const { create } = useNavigation();
+  return (
+    <EmptyState
+      title="No Transactions Yet"
+      description="Start tracking your finances by adding your first transaction."
+      actionLabel="Add Transaction"
+      onAction={() => create("transactions")}
+    />
+  );
+};
+
+export const getBudgetEmptyState = (): React.ReactNode => {
+  const { create } = useNavigation();
+  return (
+    <EmptyState
+      title="No Budgets Yet"
+      description="Create a budget to track your spending goals and stay on target."
+      actionLabel="Create Budget"
+      onAction={() => create("budgets")}
+    />
+  );
+};
+
+export const getCategoryEmptyState = (): React.ReactNode => {
+  const { create } = useNavigation();
+  return (
+    <EmptyState
+      title="No Categories Yet"
+      description="Add categories to organize and track your transactions better."
+      actionLabel="Add Category"
+      onAction={() => create("categories")}
+    />
+  );
+};
+
+export const getBankAccountEmptyState = (): React.ReactNode => {
+  const { create } = useNavigation();
+  return (
+    <EmptyState
+      title="No Bank Accounts Yet"
+      description="Link your bank accounts to start tracking all your transactions in one place."
+      actionLabel="Add Bank Account"
+      onAction={() => create("bank_accounts")}
+    />
+  );
+};
+
+export const getTagEmptyState = (): React.ReactNode => {
+  const { create } = useNavigation();
+  return (
+    <EmptyState
+      title="No Tags Yet"
+      description="Create tags to label and filter your transactions by custom attributes."
+      actionLabel="Add Tag"
+      onAction={() => create("tags")}
+    />
+  );
+};

--- a/apps/web-next/src/components/index.ts
+++ b/apps/web-next/src/components/index.ts
@@ -1,3 +1,11 @@
 export { Header } from "./header";
 export { EnvironmentBanner } from "./environment-banner";
 export { ErrorBoundary } from "./error-boundary";
+export { EmptyState } from "./EmptyState";
+export {
+  getTransactionEmptyState,
+  getBudgetEmptyState,
+  getCategoryEmptyState,
+  getBankAccountEmptyState,
+  getTagEmptyState,
+} from "./EmptyStates";

--- a/apps/web-next/src/components/resource-list/index.tsx
+++ b/apps/web-next/src/components/resource-list/index.tsx
@@ -20,6 +20,7 @@ export interface ResourceListProps {
   columns: Column[];
   showActions?: boolean;
   deleteResource?: string;
+  emptyStateBuilder?: () => React.ReactNode;
 }
 
 export const ResourceList: React.FC<ResourceListProps> = ({
@@ -27,6 +28,7 @@ export const ResourceList: React.FC<ResourceListProps> = ({
   columns,
   showActions = true,
   deleteResource,
+  emptyStateBuilder,
 }) => {
   const invalidate = useInvalidate();
   const { tableProps } = useTable({
@@ -36,7 +38,11 @@ export const ResourceList: React.FC<ResourceListProps> = ({
 
   return (
     <List>
-      <Table {...tableProps} rowKey="id">
+      <Table
+        {...tableProps}
+        rowKey="id"
+        locale={emptyStateBuilder ? { emptyText: emptyStateBuilder() } : undefined}
+      >
         {columns.map((column) => (
           <Table.Column
             key={column.dataIndex}

--- a/apps/web-next/src/pages/bank-accounts/list.tsx
+++ b/apps/web-next/src/pages/bank-accounts/list.tsx
@@ -1,4 +1,5 @@
 import { ResourceList } from "../../components/resource-list";
+import { getBankAccountEmptyState } from "../../components";
 
 export const BankAccountList = () => {
   return (
@@ -10,6 +11,7 @@ export const BankAccountList = () => {
         { dataIndex: "description", title: "Description" },
         { dataIndex: "in_use_count", title: "Usage Count" },
       ]}
+      emptyStateBuilder={getBankAccountEmptyState}
     />
   );
 };

--- a/apps/web-next/src/pages/budgets/list.tsx
+++ b/apps/web-next/src/pages/budgets/list.tsx
@@ -19,6 +19,7 @@ import {
   getProgressStatus,
   WARN_STROKE_COLOR,
 } from "../../utility/budgetAlerts";
+import { getBudgetEmptyState } from "../../components";
 
 export const BudgetList = () => {
   const invalidate = useInvalidate();
@@ -31,7 +32,7 @@ export const BudgetList = () => {
 
   return (
     <List>
-      <Table {...tableProps} rowKey="id">
+      <Table {...tableProps} rowKey="id" locale={{ emptyText: getBudgetEmptyState() }}>
         <Table.Column dataIndex="name" title="Name" sorter />
         <Table.Column
           dataIndex="type"

--- a/apps/web-next/src/pages/categories/list.tsx
+++ b/apps/web-next/src/pages/categories/list.tsx
@@ -12,6 +12,7 @@ import {
   TRANSACTION_TYPES,
   TRANSACTION_TYPE_LABELS,
 } from "../../constants/transactionTypes";
+import { getCategoryEmptyState } from "../../components";
 
 export const CategoryList = () => {
   const invalidate = useInvalidate();
@@ -44,7 +45,7 @@ export const CategoryList = () => {
         value={categoryType}
         onChange={(value) => setCategoryType(value as string)}
       />
-      <Table {...tableProps} rowKey="id">
+      <Table {...tableProps} rowKey="id" locale={{ emptyText: getCategoryEmptyState() }}>
         <Table.Column dataIndex="name" title="Name" sorter />
         <Table.Column dataIndex="description" title="Description" sorter />
         <Table.Column dataIndex="in_use_count" title="Usage Count" sorter />

--- a/apps/web-next/src/pages/tags/list.tsx
+++ b/apps/web-next/src/pages/tags/list.tsx
@@ -1,4 +1,5 @@
 import { ResourceList } from "../../components/resource-list";
+import { getTagEmptyState } from "../../components";
 
 export const TagList = () => {
   return (
@@ -10,6 +11,7 @@ export const TagList = () => {
         { dataIndex: "description", title: "Description" },
         { dataIndex: "in_use_count", title: "Usage Count" },
       ]}
+      emptyStateBuilder={getTagEmptyState}
     />
   );
 };

--- a/apps/web-next/src/pages/transactions/list.tsx
+++ b/apps/web-next/src/pages/transactions/list.tsx
@@ -19,6 +19,7 @@ import {
   TRANSACTION_TYPES,
 } from "../../constants/transactionTypes";
 import { formatAmount } from "../../utility";
+import { getTransactionEmptyState } from "../../components";
 
 const commonSelectOptions = {
   sorters: [{ field: "name", order: "asc" as const }],
@@ -110,7 +111,7 @@ export const TransactionList = () => {
         value={transactionType}
         onChange={(value) => setTransactionType(value as string)}
       />
-      <Table {...tableProps} rowKey="id">
+      <Table {...tableProps} rowKey="id" locale={{ emptyText: getTransactionEmptyState() }}>
         <Table.Column
           dataIndex={["date"]}
           title="Date"


### PR DESCRIPTION
## Why
Implements section 9 of the UX Interaction Plan. Currently, all list pages show Ant Design's default empty state with no context or call to action. Users have no guidance on how to create their first item. This improvement provides contextual, actionable empty states for better first-time user experience.

## What Changed
- Created reusable `EmptyState` component (`src/components/EmptyState.tsx`) with title, description, and CTA button
- Added empty state helpers (`src/components/EmptyStates.tsx`) for each resource type with appropriate messaging and navigation
- Wired empty states to all list pages:
  - Transactions: "Add Transaction"
  - Budgets: "Create Budget"
  - Categories: "Add Category"
  - Bank Accounts: "Add Bank Account"
  - Tags: "Add Tag"
- Enhanced `ResourceList` component to support `emptyStateBuilder` prop for flexible empty state configuration

## Key Decisions
- Used Ant Design's `<Empty>` component with `PRESENTED_IMAGE_SIMPLE` for clean, minimal styling
- Each empty state helper uses Refine's `useNavigation().create()` to navigate to the appropriate create page
- Kept the component simple and reusable rather than resource-specific implementations

## How This Affects the System
- **User-facing changes:** Empty list pages now display helpful context and a clear call-to-action button
- **No breaking changes:** This is a pure UX enhancement with no API or data model changes
- **No performance implications:** Components are lightweight and only render when tables are empty

## Testing
- Added comprehensive E2E test suite (`e2e/tests/empty-states.spec.ts`) with 5 new tests
- All 5 empty state tests passing ✅
- All 67 existing E2E tests still passing ✅
- Full test coverage for all list pages and CTA navigation
- Type checking passes without errors ✅