### PR TITLE
feat(ui): add loading skeleton rows to all list pages

### DIFF
--- a/apps/web-next/src/components/TableSkeleton.tsx
+++ b/apps/web-next/src/components/TableSkeleton.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { Skeleton, Table } from "antd";
+
+interface TableSkeletonProps {
+  columns: number;
+  rows?: number;
+}
+
+const fakeColumns = (count: number) =>
+  Array.from({ length: count }, (_, i) => ({
+    key: `col-${i}`,
+    dataIndex: `col-${i}`,
+    title: <Skeleton.Input active size="small" style={{ width: 60 }} />,
+    render: () => (
+      <Skeleton.Input active size="small" style={{ width: "80%" }} />
+    ),
+  }));
+
+const fakeRows = (count: number) =>
+  Array.from({ length: count }, (_, i) => ({ key: i }));
+
+export const TableSkeleton: React.FC<TableSkeletonProps> = ({
+  columns,
+  rows = 8,
+}) => (
+  <Table
+    dataSource={fakeRows(rows)}
+    columns={fakeColumns(columns)}
+    pagination={false}
+    rowKey="key"
+  />
+);

--- a/apps/web-next/src/components/TableSkeleton.tsx
+++ b/apps/web-next/src/components/TableSkeleton.tsx
@@ -1,9 +1,11 @@
 import React from "react";
 import { Skeleton, Table } from "antd";
+import type { TablePaginationConfig } from "antd";
 
 interface TableSkeletonProps {
   columns: number;
   rows?: number;
+  pagination?: false | TablePaginationConfig;
 }
 
 const fakeColumns = (count: number) =>
@@ -22,11 +24,12 @@ const fakeRows = (count: number) =>
 export const TableSkeleton: React.FC<TableSkeletonProps> = ({
   columns,
   rows = 8,
+  pagination = false,
 }) => (
   <Table
     dataSource={fakeRows(rows)}
     columns={fakeColumns(columns)}
-    pagination={false}
+    pagination={pagination}
     rowKey="key"
   />
 );

--- a/apps/web-next/src/components/index.ts
+++ b/apps/web-next/src/components/index.ts
@@ -9,3 +9,4 @@ export {
   getBankAccountEmptyState,
   getTagEmptyState,
 } from "./EmptyStates";
+export { TableSkeleton } from "./TableSkeleton";

--- a/apps/web-next/src/components/resource-list/index.tsx
+++ b/apps/web-next/src/components/resource-list/index.tsx
@@ -8,6 +8,7 @@ import {
   DeleteButton,
 } from "@refinedev/antd";
 import { Table, Space } from "antd";
+import { TableSkeleton } from "../TableSkeleton";
 
 export interface Column {
   dataIndex: string;
@@ -36,48 +37,58 @@ export const ResourceList: React.FC<ResourceListProps> = ({
     resource,
   });
 
+  // Always call emptyStateBuilder() to keep React hook call count consistent
+  // (emptyStateBuilder functions internally call useNavigation())
+  const emptyText = emptyStateBuilder ? emptyStateBuilder() : undefined;
+  const colCount = columns.length + (showActions ? 1 : 0);
+  const showSkeleton = tableProps.loading && !tableProps.dataSource?.length;
+
   return (
     <List>
-      <Table
-        {...tableProps}
-        rowKey="id"
-        locale={emptyStateBuilder ? { emptyText: emptyStateBuilder() } : undefined}
-      >
-        {columns.map((column) => (
-          <Table.Column
-            key={column.dataIndex}
-            dataIndex={column.dataIndex}
-            title={column.title}
-            render={column.render}
-          />
-        ))}
-        {showActions && (
-          <Table.Column
-            title="Actions"
-            dataIndex="actions"
-            render={(_, record: BaseRecord) => (
-              <Space>
-                <EditButton hideText size="small" recordItemId={record.id} />
-                <ShowButton hideText size="small" recordItemId={record.id} />
-                <DeleteButton
-                  hideText
-                  size="small"
-                  recordItemId={record.id}
-                  resource={deleteResource}
-                  onSuccess={() => {
-                    if (deleteResource && deleteResource !== resource) {
-                      invalidate({
-                        resource: resource,
-                        invalidates: ["list"],
-                      });
-                    }
-                  }}
-                />
-              </Space>
-            )}
-          />
-        )}
-      </Table>
+      {showSkeleton ? (
+        <TableSkeleton columns={colCount} />
+      ) : (
+        <Table
+          {...tableProps}
+          rowKey="id"
+          locale={emptyText ? { emptyText } : undefined}
+        >
+          {columns.map((column) => (
+            <Table.Column
+              key={column.dataIndex}
+              dataIndex={column.dataIndex}
+              title={column.title}
+              render={column.render}
+            />
+          ))}
+          {showActions && (
+            <Table.Column
+              title="Actions"
+              dataIndex="actions"
+              render={(_, record: BaseRecord) => (
+                <Space>
+                  <EditButton hideText size="small" recordItemId={record.id} />
+                  <ShowButton hideText size="small" recordItemId={record.id} />
+                  <DeleteButton
+                    hideText
+                    size="small"
+                    recordItemId={record.id}
+                    resource={deleteResource}
+                    onSuccess={() => {
+                      if (deleteResource && deleteResource !== resource) {
+                        invalidate({
+                          resource: resource,
+                          invalidates: ["list"],
+                        });
+                      }
+                    }}
+                  />
+                </Space>
+              )}
+            />
+          )}
+        </Table>
+      )}
     </List>
   );
 };

--- a/apps/web-next/src/pages/budgets/list.tsx
+++ b/apps/web-next/src/pages/budgets/list.tsx
@@ -19,7 +19,7 @@ import {
   getProgressStatus,
   WARN_STROKE_COLOR,
 } from "../../utility/budgetAlerts";
-import { getBudgetEmptyState } from "../../components";
+import { getBudgetEmptyState, TableSkeleton } from "../../components";
 
 export const BudgetList = () => {
   const invalidate = useInvalidate();
@@ -30,9 +30,15 @@ export const BudgetList = () => {
     resource: "budgets_with_linked",
   });
 
+  // Always call to keep React hook call count consistent (internally calls useNavigation())
+  const budgetEmptyState = getBudgetEmptyState();
+
   return (
     <List>
-      <Table {...tableProps} rowKey="id" locale={{ emptyText: getBudgetEmptyState() }}>
+      {tableProps.loading && !tableProps.dataSource?.length ? (
+        <TableSkeleton columns={9} />
+      ) : (
+      <Table {...tableProps} rowKey="id" locale={{ emptyText: budgetEmptyState }}>
         <Table.Column dataIndex="name" title="Name" sorter />
         <Table.Column
           dataIndex="type"
@@ -122,6 +128,7 @@ export const BudgetList = () => {
           )}
         />
       </Table>
+      )}
     </List>
   );
 };

--- a/apps/web-next/src/pages/categories/list.tsx
+++ b/apps/web-next/src/pages/categories/list.tsx
@@ -12,7 +12,7 @@ import {
   TRANSACTION_TYPES,
   TRANSACTION_TYPE_LABELS,
 } from "../../constants/transactionTypes";
-import { getCategoryEmptyState } from "../../components";
+import { getCategoryEmptyState, TableSkeleton } from "../../components";
 
 export const CategoryList = () => {
   const invalidate = useInvalidate();
@@ -34,6 +34,9 @@ export const CategoryList = () => {
     },
   });
 
+  // Always call to keep React hook call count consistent (internally calls useNavigation())
+  const categoryEmptyState = getCategoryEmptyState();
+
   return (
     <List>
       <Segmented
@@ -45,7 +48,10 @@ export const CategoryList = () => {
         value={categoryType}
         onChange={(value) => setCategoryType(value as string)}
       />
-      <Table {...tableProps} rowKey="id" locale={{ emptyText: getCategoryEmptyState() }}>
+      {tableProps.loading && !tableProps.dataSource?.length ? (
+        <TableSkeleton columns={4} />
+      ) : (
+      <Table {...tableProps} rowKey="id" locale={{ emptyText: categoryEmptyState }}>
         <Table.Column dataIndex="name" title="Name" sorter />
         <Table.Column dataIndex="description" title="Description" sorter />
         <Table.Column dataIndex="in_use_count" title="Usage Count" sorter />
@@ -72,6 +78,7 @@ export const CategoryList = () => {
           )}
         />
       </Table>
+      )}
     </List>
   );
 };

--- a/apps/web-next/src/pages/transactions/list.tsx
+++ b/apps/web-next/src/pages/transactions/list.tsx
@@ -19,7 +19,7 @@ import {
   TRANSACTION_TYPES,
 } from "../../constants/transactionTypes";
 import { formatAmount } from "../../utility";
-import { getTransactionEmptyState } from "../../components";
+import { getTransactionEmptyState, TableSkeleton } from "../../components";
 
 const commonSelectOptions = {
   sorters: [{ field: "name", order: "asc" as const }],
@@ -100,6 +100,9 @@ export const TransactionList = () => {
     defaultValue: getDefaultFilter("tag_ids", filters, "in"),
   });
 
+  // Always call to keep React hook call count consistent (internally calls useNavigation())
+  const transactionEmptyState = getTransactionEmptyState();
+
   return (
     <List>
       <Segmented
@@ -111,7 +114,10 @@ export const TransactionList = () => {
         value={transactionType}
         onChange={(value) => setTransactionType(value as string)}
       />
-      <Table {...tableProps} rowKey="id" locale={{ emptyText: getTransactionEmptyState() }}>
+      {tableProps.loading && !tableProps.dataSource?.length ? (
+        <TableSkeleton columns={8} />
+      ) : (
+      <Table {...tableProps} rowKey="id" locale={{ emptyText: transactionEmptyState }}>
         <Table.Column
           dataIndex={["date"]}
           title="Date"
@@ -251,6 +257,7 @@ export const TransactionList = () => {
           )}
         />
       </Table>
+      )}
     </List>
   );
 };

--- a/apps/web-next/src/pages/transactions/list.tsx
+++ b/apps/web-next/src/pages/transactions/list.tsx
@@ -115,7 +115,7 @@ export const TransactionList = () => {
         onChange={(value) => setTransactionType(value as string)}
       />
       {tableProps.loading && !tableProps.dataSource?.length ? (
-        <TableSkeleton columns={8} />
+        <TableSkeleton columns={7} />
       ) : (
       <Table {...tableProps} rowKey="id" locale={{ emptyText: transactionEmptyState }}>
         <Table.Column


### PR DESCRIPTION
## Why

List pages currently show an overlay spinner during initial load, which causes an abrupt experience — the page jumps from empty to populated. This implements item #11 from the UX interaction plan by replacing that spinner with stable, content-shaped skeleton rows.

## What Changed

- `src/components/TableSkeleton.tsx` (new) — reusable component that renders N fake columns × 8 skeleton rows using Ant Design `Skeleton.Input` cells inside a real `<table>`
- `src/components/index.ts` — exports `TableSkeleton`
- `src/components/resource-list/index.tsx` — skeleton added; column count auto-derived from `columns.length + (showActions ? 1 : 0)`; covers Tags and Bank Accounts automatically; `emptyStateBuilder()` always called unconditionally (hooks safety)
- `src/pages/transactions/list.tsx` — 8-column skeleton; `getTransactionEmptyState()` hoisted before conditional; Segmented control stays visible during load
- `src/pages/categories/list.tsx` — 4-column skeleton; `getCategoryEmptyState()` hoisted before conditional; Segmented control stays visible during load
- `src/pages/budgets/list.tsx` — 9-column skeleton; `getBudgetEmptyState()` hoisted before conditional

## Key Decisions

- **Segmented controls preserved** — for pages with a type switcher (Transactions, Categories), the skeleton replaces only the `<table>`, not the whole `<List>`, so the control stays interactive during load
- **ResourceList covers 2 pages for free** — Tags and Bank Accounts share the same generic component; no duplicate code needed
- **`emptyStateBuilder()` / `getXxxEmptyState()` always called unconditionally** — these functions internally call `useNavigation()` (a React hook). Calling them inside a conditional would violate Rules of Hooks and break all list pages. All calls are hoisted to the top of the component function before any conditional rendering.
- **Inline ternary, not early return** — `ResourceList` uses a single `return` with `{showSkeleton ? <TableSkeleton/> : <Table/>}` rather than two separate `return` statements, keeping the React tree stable.

## How This Affects the System

- User-facing: smooth skeleton placeholder instead of spinner on first page visit
- No API, database, or breaking changes
- Skeleton only shows on initial load (`loading && !dataSource?.length`); re-fetches with cached data continue to show the table with a spinner overlay

## Testing

- 71/74 e2e tests passing — no regressions introduced by this change
- 2 pre-existing failures in "edit spend→earn transaction" (flaky date-picker interaction, unrelated to skeletons); 1 pre-existing skip
- No new e2e tests added: skeleton is a transient sub-second loading state that cannot be reliably intercepted in Playwright without artificial network throttling