### PR TITLE
feat: notes full-text search and amount range filter in transaction list

### DIFF
--- a/apps/web-next/e2e/tests/transactions.spec.ts
+++ b/apps/web-next/e2e/tests/transactions.spec.ts
@@ -445,3 +445,87 @@ test.describe("Transactions", () => {
     await expect(page.getByText("Amount cannot be zero")).not.toBeVisible();
   });
 });
+
+test.describe("Transaction list filters", () => {
+  let testUser: { email: string; password: string; userId: string };
+
+  test.beforeAll(async () => {
+    testUser = await createTestUser();
+    await seedReferenceDataForUser(testUser.userId);
+  });
+
+  test.afterAll(async () => {
+    await cleanupReferenceDataForUser(testUser.userId);
+    await deleteTestUser(testUser.userId);
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await loginUser(page, testUser.email, testUser.password);
+  });
+
+  test.afterEach(async () => {
+    await cleanupTransactionsForUser(testUser.userId);
+  });
+
+  test("notes search filters transactions by matching text", async ({ page }) => {
+    const date = e2eCurrentMonthDate();
+    const uniqueNote = `unique-search-note-${Date.now()}`;
+
+    // Create two transactions — one with the unique note, one without
+    await createTransactionWithoutTags(page, date, "spend", "Groceries", "50.00", "Main Account", uniqueNote);
+    await createTransactionWithoutTags(page, date, "spend", "Groceries", "75.00", "Main Account", "other-note");
+
+    // Navigate to the spend tab
+    await page.goto("/transactions");
+    await page.getByRole("radiogroup", { name: "segmented control" }).getByText(/spend/i).click();
+    await page.waitForLoadState("networkidle");
+
+    // Type the unique note in the search bar
+    await page.getByRole("searchbox", { name: /search notes/i }).fill(uniqueNote);
+
+    // Wait for debounce + table re-render
+    await page.waitForTimeout(600);
+    await page.waitForLoadState("networkidle");
+
+    // Only the matching row should be visible
+    await expect(page.getByText(uniqueNote)).toBeVisible();
+    await expect(page.getByText("other-note")).not.toBeVisible();
+  });
+
+  test("notes search shows empty state when no match", async ({ page }) => {
+    const date = e2eCurrentMonthDate();
+    await createTransactionWithoutTags(page, date, "spend", "Groceries", "50.00", "Main Account", "some-note");
+
+    await page.goto("/transactions");
+    await page.getByRole("radiogroup", { name: "segmented control" }).getByText(/spend/i).click();
+    await page.waitForLoadState("networkidle");
+
+    await page.getByRole("searchbox", { name: /search notes/i }).fill("zzz-no-match-zzz");
+
+    await page.waitForTimeout(600);
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.getByText("some-note")).not.toBeVisible();
+  });
+
+  test("amount range filter shows only transactions within range", async ({ page }) => {
+    const date = e2eCurrentMonthDate();
+    await createTransactionWithoutTags(page, date, "spend", "Groceries", "30.00", "Main Account", "low-amount");
+    await createTransactionWithoutTags(page, date, "spend", "Groceries", "200.00", "Main Account", "high-amount");
+
+    await page.goto("/transactions");
+    await page.getByRole("radiogroup", { name: "segmented control" }).getByText(/spend/i).click();
+    await page.waitForLoadState("networkidle");
+
+    // Open amount filter dropdown
+    await page.getByRole("columnheader", { name: "Amount" }).locator(".ant-table-filter-trigger").click();
+    await page.getByPlaceholder("Min").fill("100");
+    // Trigger onChange by pressing Tab
+    await page.keyboard.press("Tab");
+    await page.waitForLoadState("networkidle");
+
+    // Only the high-amount row should be visible
+    await expect(page.getByText("high-amount")).toBeVisible();
+    await expect(page.getByText("low-amount")).not.toBeVisible();
+  });
+});

--- a/apps/web-next/src/pages/transactions/list.tsx
+++ b/apps/web-next/src/pages/transactions/list.tsx
@@ -11,8 +11,8 @@ import {
   FilterDropdown,
   getDefaultFilter,
 } from "@refinedev/antd";
-import { Table, Space, Segmented, Select, DatePicker, InputNumber } from "antd";
-import { useState } from "react";
+import { Table, Space, Segmented, Select, DatePicker, InputNumber, Input } from "antd";
+import { useState, useEffect } from "react";
 import dayjs from "dayjs";
 import {
   TRANSACTION_TYPE_LABELS,
@@ -54,6 +54,7 @@ export const TransactionList = () => {
   const [transactionType, setTransactionType] = useState<string>(
     TRANSACTION_TYPES.SPEND
   );
+  const [searchQuery, setSearchQuery] = useState<string>("");
 
   const { tableProps, filters, setFilters } = useTable({
     syncWithLocation: true,
@@ -71,6 +72,20 @@ export const TransactionList = () => {
       ],
     },
   });
+
+  // Debounce notes search → update table filter
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setFilters([
+        {
+          field: "notes",
+          operator: "contains",
+          value: searchQuery || undefined,
+        },
+      ]);
+    }, 400);
+    return () => clearTimeout(timer);
+  }, [searchQuery]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Category select - filtered by current transaction type
   const { selectProps: categorySelectProps } = useSelect({
@@ -104,7 +119,19 @@ export const TransactionList = () => {
   const transactionEmptyState = getTransactionEmptyState();
 
   return (
-    <List>
+    <List
+      headerButtons={
+        <Input.Search
+          placeholder="Search notes…"
+          allowClear
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          onSearch={(val) => setSearchQuery(val)}
+          style={{ width: 260 }}
+          aria-label="search notes"
+        />
+      }
+    >
       <Segmented
         aria-label="segmented control"
         options={Object.values(TRANSACTION_TYPES).map((type) => ({
@@ -178,15 +205,48 @@ export const TransactionList = () => {
           title="Amount"
           sorter
           render={(value: number) => formatAmount(value)}
-          filterDropdown={(props) => (
-            <FilterDropdown {...props}>
-              <InputNumber
-                placeholder="Filter by amount"
-                style={{ width: "100%" }}
-              />
-            </FilterDropdown>
-          )}
-          defaultFilteredValue={getDefaultFilter("amount", filters, "eq")}
+          filteredValue={getDefaultFilter("amount", filters, "between") ?? null}
+          filterDropdown={({ confirm }) => {
+            const activeVal = getDefaultFilter("amount", filters, "between");
+            const [minVal, maxVal] = Array.isArray(activeVal) && activeVal.length === 2
+              ? [activeVal[0] as number, activeVal[1] as number]
+              : [undefined, undefined];
+            return (
+              <div style={{ padding: 8, display: "flex", gap: 8, alignItems: "center" }}>
+                <InputNumber
+                  placeholder="Min"
+                  value={minVal}
+                  style={{ width: 110 }}
+                  onChange={(min) => {
+                    setFilters([
+                      {
+                        field: "amount",
+                        operator: "between",
+                        value: min != null || maxVal != null ? [min ?? 0, maxVal ?? Infinity] : undefined,
+                      },
+                    ]);
+                    confirm({ closeDropdown: false });
+                  }}
+                />
+                <span>–</span>
+                <InputNumber
+                  placeholder="Max"
+                  value={maxVal}
+                  style={{ width: 110 }}
+                  onChange={(max) => {
+                    setFilters([
+                      {
+                        field: "amount",
+                        operator: "between",
+                        value: minVal != null || max != null ? [minVal ?? 0, max ?? Infinity] : undefined,
+                      },
+                    ]);
+                    confirm({ closeDropdown: false });
+                  }}
+                />
+              </div>
+            );
+          }}
         />
         <Table.Column
           key="tag_ids"


### PR DESCRIPTION
## Why

Item #5 from the UX Interaction Plan: the notes column had no search, and the amount filter was an exact-match (`eq`) which is practically useless. This brings free-text notes search and a proper min/max amount range.

## What Changed

- **`apps/web-next/src/pages/transactions/list.tsx`**
  - Added `Input.Search` in the `<List headerButtons>` slot (debounced 400ms, case-insensitive via `contains` → Supabase `ilike`)
  - Replaced single `InputNumber` exact-match amount filter with a Min / Max range using `operator: "between"` — mirrors the existing date range UX pattern

- **`apps/web-next/e2e/tests/transactions.spec.ts`**
  - New `describe("Transaction list filters")` block with 3 tests: notes match, notes no-match, amount range

## Key Decisions

- Decision: Use Refine's `contains` operator (not `containsi`)
- Reasoning: The Supabase data provider already maps `contains` → `ilike` (case-insensitive); `containsi` is not in Refine's type union
- Alternatives considered: `containsi` with type cast — rejected in favour of the correct typed operator

- Decision: Debounce via `useEffect` + `setTimeout`
- Reasoning: No new library dependency needed
- Alternatives considered: `use-debounce` package — not worth adding for a single use

## How This Affects the System

- User-facing changes: search bar appears above the transaction table; amount column filter now shows Min / Max fields
- API changes: none
- Performance implications: none (debounce prevents over-fetching)
- Database changes: none
- Breaking changes: none

## Testing

- New tests added: `Transaction list filters` describe block (3 tests) in `e2e/tests/transactions.spec.ts`
- Existing tests status: unaffected
- Manual testing performed: type check and lint on changed files pass clean
- Edge cases tested: notes no-match (empty state), amount with only min set
- Test files modified or added: `e2e/tests/transactions.spec.ts`