### PR TITLE
bugfix: stabilize e2e waits and harden budget test setup

### DIFF
--- a/apps/web-next/e2e/tests/budgets.spec.ts
+++ b/apps/web-next/e2e/tests/budgets.spec.ts
@@ -11,7 +11,7 @@ import {
 } from "../utils/test-helpers";
 
 test.describe("Budgets", () => {
-  let testUser: { email: string; password: string; userId: string };
+  let testUser: { email: string; password: string; userId: string } | undefined;
 
   test.beforeAll(async () => {
     testUser = await createTestUser();
@@ -19,12 +19,14 @@ test.describe("Budgets", () => {
   });
 
   test.afterAll(async () => {
+    if (!testUser) return;
     await supabaseAdmin.from("budgets").delete().eq("user_id", testUser.userId);
     await cleanupReferenceDataForUser(testUser.userId);
     await deleteTestUser(testUser.userId);
   });
 
   test.beforeEach(async ({ page }) => {
+    if (!testUser) throw new Error("Budgets test user was not initialized");
     await loginUser(page, testUser.email, testUser.password);
   });
 
@@ -197,7 +199,7 @@ test.describe("Budgets", () => {
 });
 
 test.describe("Budget alert states", () => {
-  let testUser: { email: string; password: string; userId: string };
+  let testUser: { email: string; password: string; userId: string } | undefined;
 
   test.beforeAll(async () => {
     testUser = await createTestUser();
@@ -205,6 +207,7 @@ test.describe("Budget alert states", () => {
   });
 
   test.afterAll(async () => {
+    if (!testUser) return;
     await supabaseAdmin
       .from("transactions")
       .delete()
@@ -215,6 +218,7 @@ test.describe("Budget alert states", () => {
   });
 
   test.beforeEach(async ({ page }) => {
+    if (!testUser) throw new Error("Budget alert test user was not initialized");
     await loginUser(page, testUser.email, testUser.password);
   });
 
@@ -272,6 +276,7 @@ test.describe("Budget alert states", () => {
   }
 
   test("spend budget at 85% shows Near limit tag in list", async ({ page }) => {
+    if (!testUser) throw new Error("Budget alert test user was not initialized");
     const budgetName = await seedBudgetAtPercent(testUser.userId, 85);
 
     await page.goto("/budgets");
@@ -283,6 +288,7 @@ test.describe("Budget alert states", () => {
   });
 
   test("spend budget at 100% shows Over budget tag in list", async ({ page }) => {
+    if (!testUser) throw new Error("Budget alert test user was not initialized");
     const budgetName = await seedBudgetAtPercent(testUser.userId, 100);
 
     await page.goto("/budgets");
@@ -296,6 +302,7 @@ test.describe("Budget alert states", () => {
   test("spend budget at 100% shows Over budget tag on dashboard", async ({
     page,
   }) => {
+    if (!testUser) throw new Error("Budget alert test user was not initialized");
     const budgetName = await seedBudgetAtPercent(testUser.userId, 100);
 
     await page.goto("/");

--- a/apps/web-next/e2e/tests/bulk-upload.spec.ts
+++ b/apps/web-next/e2e/tests/bulk-upload.spec.ts
@@ -41,7 +41,11 @@ test.describe("Bulk Upload", () => {
     await page
       .getByRole("button", { name: /yes.*delete.*everything/i })
       .click();
-    await expect(page.getByText(/data reset complete/i)).toBeVisible();
+    const successAlert = page
+      .getByRole("tabpanel", { name: /danger zone/i })
+      .getByRole("alert")
+      .filter({ hasText: /data reset complete/i });
+    await expect(successAlert).toBeVisible();
 
     // Go back to settings and switch to Import & Export tab to upload
     await page.goto("/settings");
@@ -125,7 +129,11 @@ test.describe("Bulk Upload", () => {
     await page
       .getByRole("button", { name: /yes.*delete.*everything/i })
       .click();
-    await expect(page.getByText(/data reset complete/i)).toBeVisible();
+    const successAlert = page
+      .getByRole("tabpanel", { name: /danger zone/i })
+      .getByRole("alert")
+      .filter({ hasText: /data reset complete/i });
+    await expect(successAlert).toBeVisible();
 
     // Go to Import & Export tab
     await page.goto("/settings");

--- a/apps/web-next/e2e/tests/dashboard-month-range.spec.ts
+++ b/apps/web-next/e2e/tests/dashboard-month-range.spec.ts
@@ -1,5 +1,10 @@
 import { expect, test, type Page } from "@playwright/test";
-import { createTestUser, deleteTestUser, loginUser } from "../utils/test-helpers";
+import {
+  createTestUser,
+  deleteTestUser,
+  loginUser,
+  waitForChartsTabReady,
+} from "../utils/test-helpers";
 
 const chartDataEndpointPattern =
   /\/rest\/v1\/(view_monthly_totals|view_monthly_category_totals|view_monthly_tagged_type_totals)\b/i;
@@ -52,7 +57,7 @@ test.describe("Dashboard month range validation", () => {
       });
 
       await page.getByRole("tab", { name: /charts/i }).click();
-      await page.waitForLoadState("networkidle");
+      await waitForChartsTabReady(page);
 
       await openMonthRangeSelect("To year", page);
       await page.keyboard.press("ArrowDown");

--- a/apps/web-next/e2e/tests/data-reset-isolation.spec.ts
+++ b/apps/web-next/e2e/tests/data-reset-isolation.spec.ts
@@ -107,7 +107,11 @@ test.describe("Data Reset Isolation", () => {
       .click();
 
     // Verify success with semantic locator
-    await expect(pageA.getByText(/data reset complete/i)).toBeVisible();
+    const successAlert = pageA
+      .getByRole("tabpanel", { name: /danger zone/i })
+      .getByRole("alert")
+      .filter({ hasText: /data reset complete/i });
+    await expect(successAlert).toBeVisible();
 
     // Clean up User A's context
     await contextA.close();

--- a/apps/web-next/e2e/tests/data-reset.spec.ts
+++ b/apps/web-next/e2e/tests/data-reset.spec.ts
@@ -47,14 +47,18 @@ test.describe("Data Reset", () => {
       .click();
 
     // Verify success message
-    await expect(page.getByText(/data reset complete/i)).toBeVisible();
+    const successAlert = page
+      .getByRole("tabpanel", { name: /danger zone/i })
+      .getByRole("alert")
+      .filter({ hasText: /data reset complete/i });
+    await expect(successAlert).toBeVisible();
 
     // Verify counts are shown
-    await expect(page.getByText(/•\s*\d+\s+budgets deleted/i)).toBeVisible();
-    await expect(page.getByText(/transactions deleted/i)).toBeVisible();
-    await expect(page.getByText(/categories deleted/i)).toBeVisible();
-    await expect(page.getByText(/tags deleted/i)).toBeVisible();
-    await expect(page.getByText(/bank accounts deleted/i)).toBeVisible();
+    await expect(successAlert).toContainText(/•\s*\d+\s+budgets deleted/i);
+    await expect(successAlert).toContainText(/transactions deleted/i);
+    await expect(successAlert).toContainText(/categories deleted/i);
+    await expect(successAlert).toContainText(/tags deleted/i);
+    await expect(successAlert).toContainText(/bank accounts deleted/i);
   });
 
   test("user can cancel data reset", async ({ page }) => {
@@ -113,7 +117,11 @@ test.describe("Data Reset", () => {
       .click();
 
     // Wait for success message
-    await expect(page.getByText(/data reset complete/i)).toBeVisible();
+    const successAlert = page
+      .getByRole("tabpanel", { name: /danger zone/i })
+      .getByRole("alert")
+      .filter({ hasText: /data reset complete/i });
+    await expect(successAlert).toBeVisible();
 
     // Verify no transactions exist in database
     const { data: transactions } = await supabaseAdmin
@@ -148,7 +156,11 @@ test.describe("Data Reset", () => {
       .click();
 
     // Wait for success message
-    await expect(page.getByText(/data reset complete/i)).toBeVisible();
+    const successAlert = page
+      .getByRole("tabpanel", { name: /danger zone/i })
+      .getByRole("alert")
+      .filter({ hasText: /data reset complete/i });
+    await expect(successAlert).toBeVisible();
 
     // Verify no categories exist in database
     const { data: categories } = await supabaseAdmin
@@ -180,8 +192,12 @@ test.describe("Data Reset", () => {
       .getByRole("button", { name: /yes.*delete.*everything/i })
       .click();
 
-    await expect(page.getByText(/data reset complete/i)).toBeVisible();
-    await expect(page.getByText(/•\s*1\s+budgets deleted/i)).toBeVisible();
+    const successAlert = page
+      .getByRole("tabpanel", { name: /danger zone/i })
+      .getByRole("alert")
+      .filter({ hasText: /data reset complete/i });
+    await expect(successAlert).toBeVisible();
+    await expect(successAlert).toContainText(/•\s*1\s+budgets deleted/i);
 
     const { data: budgets } = await supabaseAdmin
       .from("budgets")

--- a/apps/web-next/e2e/tests/settings-rpc-resilience.spec.ts
+++ b/apps/web-next/e2e/tests/settings-rpc-resilience.spec.ts
@@ -48,8 +48,12 @@ test.describe("Settings RPC resilience", () => {
     await page.locator("input[type='file']").setInputFiles(fixturePath);
     await page.getByRole("button", { name: /^upload$/i, exact: true }).click();
 
-    await expect(page.getByRole("alert").filter({ hasText: /error/i })).toBeVisible();
-    await expect(page.getByText(/simulated bulk upload rpc failure/i)).toBeVisible();
+    const errorAlert = page
+      .getByRole("tabpanel", { name: /import.*export/i })
+      .getByRole("alert")
+      .filter({ hasText: /error/i });
+    await expect(errorAlert).toBeVisible();
+    await expect(errorAlert).toContainText(/simulated bulk upload rpc failure/i);
   });
 
   test("data reset closes modal and shows standardized reset error notification", async ({
@@ -76,7 +80,18 @@ test.describe("Settings RPC resilience", () => {
       .click();
 
     await expect(page.getByRole("dialog", { name: /reset all data/i })).not.toBeVisible();
-    await expect(page.getByText(/failed to reset data/i)).toBeVisible();
-    await expect(page.getByText(/simulated reset rpc failure/i)).toBeVisible();
+
+    const errorAlert = page
+      .getByRole("tabpanel", { name: /danger zone/i })
+      .getByRole("alert")
+      .filter({ hasText: /error/i });
+    await expect(errorAlert).toBeVisible();
+    await expect(errorAlert).toContainText(/simulated reset rpc failure/i);
+
+    const notification = page
+      .locator(".ant-notification-notice")
+      .filter({ hasText: /failed to reset data/i });
+    await expect(notification).toBeVisible();
+    await expect(notification).toContainText(/simulated reset rpc failure/i);
   });
 });

--- a/apps/web-next/e2e/tests/transactions.spec.ts
+++ b/apps/web-next/e2e/tests/transactions.spec.ts
@@ -205,7 +205,8 @@ test.describe("Transactions", () => {
           .click();
 
         // Verify the edited transaction row.
-        // Extended timeout guards against slow CI re-renders after networkidle.
+        // Extended timeout guards against slow CI re-renders while the updated
+        // transaction list settles after the edit/tab-change flow.
         const editedRow = getTransactionRow(page, {
           note: newNote,
           date: newDate,

--- a/apps/web-next/e2e/tests/transactions.spec.ts
+++ b/apps/web-next/e2e/tests/transactions.spec.ts
@@ -9,7 +9,8 @@ import {
   e2eCurrentMonthDate,
   createTransactionWithoutTags,
   getTransactionRow,
-  waitForFormReady,
+  waitForTransactionEditReady,
+  selectFromVisibleAntdDropdown,
 } from "../utils/test-helpers";
 
 test.describe("Transactions", () => {
@@ -136,8 +137,7 @@ test.describe("Transactions", () => {
         // (e.g. categories for the current type) to settle before touching dropdowns.
         // Without this, the in-flight categories fetch can cause a React re-render
         // that detaches Type dropdown options mid-click.
-        await waitForFormReady(page, "transaction-edit-form");
-        await page.waitForLoadState("networkidle");
+        await waitForTransactionEditReady(page);
 
         // Change date: fill() focuses + clears the input; Enter confirms the date
         // and closes the calendar popup cleanly before we touch the next field.
@@ -147,21 +147,19 @@ test.describe("Transactions", () => {
         await page.keyboard.press("Enter");
 
         // Change type
-        await page
-          .getByRole("combobox", { name: "* Type" })
-          .click({ force: true });
-        await page.getByTitle(new RegExp(`^${toType}$`, "i")).click();
+        await selectFromVisibleAntdDropdown(page, "* Type", toType);
         await expect(
-          page.locator("#root").getByTitle(new RegExp(`^${toType}$`, "i"))
+          page
+            .locator(".ant-select-selection-item")
+            .filter({ hasText: new RegExp(`^${toType}$`, "i") })
         ).toBeVisible();
 
         // Change category (should show only categories for new type)
-        await page
-          .getByRole("combobox", { name: "* Category" })
-          .click({ force: true });
-        await page.getByTitle(new RegExp(`^${toCategory}$`, "i")).click();
+        await selectFromVisibleAntdDropdown(page, "* Category", toCategory);
         await expect(
-          page.locator("#root").getByTitle(new RegExp(`^${toCategory}$`, "i"))
+          page
+            .locator(".ant-select-selection-item")
+            .filter({ hasText: new RegExp(`^${toCategory}$`, "i") })
         ).toBeVisible();
 
         // Change amount
@@ -169,14 +167,15 @@ test.describe("Transactions", () => {
         await page.getByLabel("Amount").fill(toAmount);
 
         // Change bank account
-        await page
-          .getByRole("combobox", { name: "* Bank Account" })
-          .click({ force: true });
-        await page.getByTitle(new RegExp("^Secondary Account$", "i")).click();
+        await selectFromVisibleAntdDropdown(
+          page,
+          "* Bank Account",
+          "Secondary Account"
+        );
         await expect(
-          page
-            .locator("#root")
-            .getByTitle(new RegExp("^Secondary Account$", "i"))
+          page.locator(".ant-select-selection-item").filter({
+            hasText: /^Secondary Account$/i,
+          })
         ).toBeVisible();
 
         // Change notes
@@ -204,7 +203,6 @@ test.describe("Transactions", () => {
           .getByRole("radiogroup", { name: "segmented control" })
           .getByText(new RegExp(toType, "i"))
           .click();
-        await page.waitForLoadState("networkidle");
 
         // Verify the edited transaction row.
         // Extended timeout guards against slow CI re-renders after networkidle.
@@ -393,7 +391,6 @@ test.describe("Transactions", () => {
       .getByRole("radiogroup", { name: "segmented control" })
       .getByText(new RegExp("spend", "i"))
       .click();
-    await page.waitForLoadState("networkidle");
 
     // Verify the transaction appears in the list with the tag
     const row = getTransactionRow(page, {
@@ -434,18 +431,23 @@ test.describe("Transactions", () => {
     ).toBeVisible();
 
     // Wait for form to finish loading
-    await waitForFormReady(page, "transaction-edit-form");
-    await page.waitForLoadState("networkidle");
+    await waitForTransactionEditReady(page);
 
     // Add tags to the transaction
-    await page.getByRole("combobox", { name: "Tags" }).click();
-    await page.getByTitle(new RegExp("^essentials$", "i")).click();
+    await page.getByRole("combobox", { name: "Tags" }).click({ force: true });
+    await page
+      .locator(".ant-select-dropdown:visible")
+      .getByTitle(/^essentials$/i)
+      .click();
     await expect(
-      page.locator("#root").getByTitle(new RegExp("^essentials$", "i"))
+      page.locator(".ant-select-selection-item").filter({ hasText: /^essentials$/i })
     ).toBeVisible();
-    await page.getByTitle(new RegExp("^monthly$", "i")).click();
+    await page
+      .locator(".ant-select-dropdown:visible")
+      .getByTitle(/^monthly$/i)
+      .click();
     await expect(
-      page.locator("#root").getByTitle(new RegExp("^monthly$", "i"))
+      page.locator(".ant-select-selection-item").filter({ hasText: /^monthly$/i })
     ).toBeVisible();
     await page.keyboard.press("Escape");
 
@@ -463,7 +465,6 @@ test.describe("Transactions", () => {
       .getByRole("radiogroup", { name: "segmented control" })
       .getByText(new RegExp("spend", "i"))
       .click();
-    await page.waitForLoadState("networkidle");
 
     // Verify the transaction row still exists
     const updatedRow = getTransactionRow(page, {
@@ -509,12 +510,10 @@ test.describe("Transactions", () => {
     // Wait for the form and all background queries (initial categories fetch) to
     // settle before touching any dropdown — otherwise the in-flight categories
     // query causes a React re-render that detaches Type dropdown options mid-click.
-    await waitForFormReady(page, "transaction-edit-form");
-    await page.waitForLoadState("networkidle");
+    await waitForTransactionEditReady(page);
 
     // Change to earn type
-    await page.getByRole("combobox", { name: "* Type" }).click({ force: true });
-    await page.getByTitle(new RegExp("^earn$", "i")).click();
+    await selectFromVisibleAntdDropdown(page, "* Type", "earn");
     await expect(
       page.locator(".ant-select-selection-item").filter({ hasText: /^earn$/i })
     ).toBeVisible();
@@ -525,14 +524,15 @@ test.describe("Transactions", () => {
       .click({ force: true });
 
     // Should show earn categories (Salary)
-    await page.getByText("Salary");
+    await expect(
+      page.locator(".ant-select-dropdown:visible").getByText("Salary", { exact: true })
+    ).toBeVisible();
 
     // Close dropdown
     await page.keyboard.press("Escape");
 
     // Change to save type
-    await page.getByRole("combobox", { name: "* Type" }).click({ force: true });
-    await page.getByTitle(new RegExp("^save$", "i")).click();
+    await selectFromVisibleAntdDropdown(page, "* Type", "save");
     await expect(
       page.locator(".ant-select-selection-item").filter({ hasText: /^save$/i })
     ).toBeVisible();
@@ -543,7 +543,9 @@ test.describe("Transactions", () => {
       .click({ force: true });
 
     // Should show save categories (Savings)
-    await page.getByText("Savings");
+    await expect(
+      page.locator(".ant-select-dropdown:visible").getByText("Savings", { exact: true })
+    ).toBeVisible();
   });
 
   test("transaction amount field rejects zero but allows negative values", async ({
@@ -583,4 +585,3 @@ test.describe("Transactions", () => {
     await expect(page.getByText("low-amount")).not.toBeVisible();
   });
 });
-

--- a/apps/web-next/e2e/utils/test-helpers.ts
+++ b/apps/web-next/e2e/utils/test-helpers.ts
@@ -37,19 +37,37 @@ export async function createTestUser(seed?: string) {
     ? `test-${seed}-${Date.now()}@example.com`
     : `test-${Date.now()}@example.com`;
   const password = "TestPassword123!";
+  const maxAttempts = 3;
+  const backoffMs = [200, 500, 1000];
 
-  const { data, error } = await supabaseAdmin.auth.admin.createUser({
-    email,
-    password,
-    email_confirm: true,
-  });
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const { data, error } = await supabaseAdmin.auth.admin.createUser({
+      email,
+      password,
+      email_confirm: true,
+    });
 
-  if (error) {
-    console.error("Failed to create test user:", error.message, error);
-    throw error;
+    if (!error) {
+      const userId = (data as { user?: { id?: string } } | null)?.user?.id;
+      if (!userId) {
+        throw new Error("Supabase createUser succeeded without returning user id");
+      }
+      return { email, password, userId };
+    }
+
+    const status = (error as { status?: number }).status;
+    const code = (error as { code?: string }).code;
+    const isRetryable = status === 500 || code === "unexpected_failure";
+
+    if (!isRetryable || attempt === maxAttempts) {
+      console.error("Failed to create test user:", error.message, error);
+      throw error;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, backoffMs[attempt - 1]));
   }
-  // `data.user` structure comes from supabase-js response shape
-  return { email, password, userId: (data as any).user.id };
+
+  throw new Error("Failed to create test user after retries");
 }
 
 export async function deleteTestUser(userId: string) {
@@ -120,6 +138,30 @@ export async function waitForFormReady(page: Page, testId: string) {
   const form = page.getByTestId(testId);
   // Wait for form to exist and not be in loading state
   await expect(form).toHaveAttribute("aria-busy", "false");
+}
+
+export async function waitForTransactionEditReady(page: Page) {
+  await waitForFormReady(page, "transaction-edit-form");
+  await expect(page.getByRole("heading", { name: "Edit Transaction" })).toBeVisible();
+  await expect(page.getByRole("combobox", { name: "* Type" })).toBeVisible();
+  await expect(page.getByRole("combobox", { name: "* Category" })).toBeVisible();
+}
+
+export async function waitForChartsTabReady(page: Page) {
+  await expect(page.getByText("Income vs Spending vs Savings")).toBeVisible();
+}
+
+export async function selectFromVisibleAntdDropdown(
+  page: Page,
+  comboboxName: string,
+  optionTitle: string
+) {
+  await page.getByRole("combobox", { name: comboboxName }).click({ force: true });
+  const option = page
+    .locator(".ant-select-dropdown:visible")
+    .getByTitle(new RegExp(`^${optionTitle}$`, "i"));
+  await option.waitFor({ state: "visible" });
+  await option.click();
 }
 
 // Seed minimal reference data (categories, bank accounts, tags) for a given user

--- a/apps/web-next/e2e/utils/test-helpers.ts
+++ b/apps/web-next/e2e/utils/test-helpers.ts
@@ -156,10 +156,11 @@ export async function selectFromVisibleAntdDropdown(
   comboboxName: string,
   optionTitle: string
 ) {
+  const escapedTitle = optionTitle.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   await page.getByRole("combobox", { name: comboboxName }).click({ force: true });
   const option = page
     .locator(".ant-select-dropdown:visible")
-    .getByTitle(new RegExp(`^${optionTitle}$`, "i"));
+    .getByTitle(new RegExp(`^${escapedTitle}$`, "i"));
   await option.waitFor({ state: "visible" });
   await option.click();
 }

--- a/docs/superpowers/plans/2026-05-10-frontend-architecture-remaining-items.md
+++ b/docs/superpowers/plans/2026-05-10-frontend-architecture-remaining-items.md
@@ -1,0 +1,520 @@
+# Frontend Architecture Remaining Items (M3, M4, L3) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete the remaining frontend architecture work by standardizing error handling, extracting a shared month-range picker, and documenting/typing intentional direct Supabase RPC usage.
+
+**Architecture:** Keep existing Refine resource/data-provider flows intact and make only focused UI-layer changes. Centralize direct RPC calls in one typed utility module and route user-visible failures through Refine notifications for consistency. Reuse one shared controlled picker component for all dashboard month-range selection UX and validation.
+
+**Tech Stack:** React 19, TypeScript, Refine (`@refinedev/core`, `@refinedev/antd`), Ant Design 5, Supabase JS client, Playwright E2E
+
+---
+
+## Scope Check
+
+This plan covers a single subsystem (`apps/web-next` frontend architecture hygiene) and only the pending items from the spec:
+- M3: Standardize error handling across data-fetching hooks/forms
+- M4: Extract shared month-range picker and add range validation
+- L3: Audit/document intentional direct Supabase RPC usage and centralize wrappers
+
+Already-completed spec items (H1, H2, H3, M1, M2, L1, L2) are out of scope.
+
+## File Structure
+
+### New Files
+- `apps/web-next/src/utility/rpc.ts`  
+  Single typed module for frontend-kept RPC calls and argument/result types.
+- `apps/web-next/src/components/MonthRangePicker.tsx`  
+  Shared controlled picker used by dashboard period/charts selectors.
+- `apps/web-next/e2e/tests/dashboard-month-range.spec.ts`  
+  Covers invalid range validation + blocked data rendering.
+- `apps/web-next/e2e/tests/settings-rpc-resilience.spec.ts`  
+  Covers bulk upload/reset failures surfacing clear user-visible notifications.
+
+### Modified Files
+- `apps/web-next/src/utility/index.ts`  
+  Re-export RPC wrappers and add architecture convention comment.
+- `apps/web-next/src/pages/settings/index.tsx`  
+  Replace inline `supabaseClient.rpc` usage with typed wrappers + intentional markers.
+- `apps/web-next/src/hooks/useTransactionForm.ts`  
+  Switch direct RPC calls to wrapper functions + intentional markers retained in wrapper.
+- `apps/web-next/src/pages/budgets/create.tsx`  
+  Replace `message.error` with Refine notification; remove silent return on missing budget ID.
+- `apps/web-next/src/pages/budgets/edit.tsx`  
+  Replace `message.error` with Refine notification; remove silent return on missing edit ID.
+- `apps/web-next/src/pages/dashboard/components/PeriodTab.tsx`  
+  Replace inline year/month selector with `MonthRangePicker` (`singleMonth` mode).
+- `apps/web-next/src/pages/dashboard/ChartsTab.tsx`  
+  Replace inline start/end selectors with `MonthRangePicker` and invalid-range guard UI.
+- `apps/web-next/src/pages/dashboard/index.tsx`  
+  (only if needed) pass selector props cleanly into tab children.
+
+---
+
+### Task 1: Add typed RPC wrapper layer and mark intentional direct Supabase usage (L3)
+
+**Files:**
+- Create: `apps/web-next/src/utility/rpc.ts`
+- Modify: `apps/web-next/src/utility/index.ts`
+- Modify: `apps/web-next/src/pages/settings/index.tsx`
+- Modify: `apps/web-next/src/hooks/useTransactionForm.ts`
+- Test: `apps/web-next/e2e/tests/settings-rpc-resilience.spec.ts`
+
+- [ ] **Step 1: Write the failing test for settings RPC failures**
+
+```ts
+import { test, expect } from "@playwright/test";
+import { createTestUser, deleteTestUser, loginUser } from "../utils/test-helpers";
+
+test.describe("Settings RPC resilience", () => {
+  test("bulk upload failure surfaces a visible error", async ({ page }) => {
+    const { email, password, userId } = await createTestUser("settings-rpc");
+    try {
+      await loginUser(page, email, password);
+      await page.goto("/settings");
+      await page.getByRole("tab", { name: /import.*export/i }).click();
+      await expect(page.getByText("Bulk Upload")).toBeVisible();
+      // This assertion will fail until error handling is normalized in task 2.
+      await expect(page.getByText(/failed to upload data/i)).toBeVisible();
+    } finally {
+      await deleteTestUser(userId);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web-next && npm run test:e2e:ci -- e2e/tests/settings-rpc-resilience.spec.ts`  
+Expected: FAIL because standardized notification/error copy is not implemented yet.
+
+- [ ] **Step 3: Write minimal RPC wrapper implementation**
+
+```ts
+// apps/web-next/src/utility/rpc.ts
+import { supabaseClient } from "./supabaseClient";
+
+export interface BulkUploadPayload {
+  categories?: Array<{ type: string; name: string; description?: string | null }>;
+  bank_accounts?: Array<{ name: string; description?: string | null }>;
+  tags?: Array<{ name: string; description?: string | null }>;
+  transactions?: Array<{
+    date: string;
+    type: string;
+    amount: number;
+    category?: string | null;
+    bank_account?: string | null;
+    tags?: string[] | null;
+    notes?: string | null;
+  }>;
+}
+
+// INTENTIONAL_DIRECT_SUPABASE: RPC is backend-owned and not a Refine resource CRUD operation.
+export const bulkUploadData = (payload: BulkUploadPayload) =>
+  supabaseClient.rpc("bulk_upload_data", { p_payload: payload });
+
+// INTENTIONAL_DIRECT_SUPABASE: RPC executes destructive account-scoped reset logic in DB.
+export const resetUserData = () => supabaseClient.rpc("reset_user_data");
+
+// INTENTIONAL_DIRECT_SUPABASE: atomic transaction + tag write path is implemented as DB RPC.
+export const createTransactionWithTags = (
+  transaction: Record<string, unknown>,
+  tagIds: string[]
+) => supabaseClient.rpc("create_transaction_with_tags", { p_transaction: transaction, p_tag_ids: tagIds });
+
+// INTENTIONAL_DIRECT_SUPABASE: atomic transaction + tag update path is implemented as DB RPC.
+export const updateTransactionWithTags = (
+  transactionId: string,
+  transaction: Record<string, unknown>,
+  tagIds: string[]
+) =>
+  supabaseClient.rpc("update_transaction_with_tags", {
+    p_transaction_id: transactionId,
+    p_transaction: transaction,
+    p_tag_ids: tagIds,
+  });
+```
+
+- [ ] **Step 4: Wire callers to wrappers and add utility convention comment**
+
+```ts
+// apps/web-next/src/utility/index.ts
+// Direct Supabase calls outside Refine data hooks must either:
+// 1) surface errors via useNotification in component scope, or
+// 2) return typed errors to callers for explicit handling.
+// Never silently swallow Supabase errors.
+export * from "./supabaseClient";
+export * from "./currency";
+export * from "./rpc";
+```
+
+```ts
+// settings/index.tsx (imports)
+import { bulkUploadData, resetUserData } from "../../utility";
+
+// replace supabaseClient.rpc("bulk_upload_data", { p_payload: payload })
+const { data, error } = await bulkUploadData(payload);
+
+// replace supabaseClient.rpc("reset_user_data")
+const { data, error: rpcError } = await resetUserData();
+```
+
+```ts
+// useTransactionForm.ts (imports)
+import { createTransactionWithTags, updateTransactionWithTags } from "../utility";
+
+// replace direct rpc calls
+const result = await createTransactionWithTags(transactionFields, tagIds);
+const result = await updateTransactionWithTags(id, transactionFields, tagIds);
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd apps/web-next && npm run test:e2e:ci -- e2e/tests/settings-rpc-resilience.spec.ts`  
+Expected: PASS once error copy/notification behavior in Task 2 is completed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add \
+  apps/web-next/src/utility/rpc.ts \
+  apps/web-next/src/utility/index.ts \
+  apps/web-next/src/pages/settings/index.tsx \
+  apps/web-next/src/hooks/useTransactionForm.ts \
+  apps/web-next/e2e/tests/settings-rpc-resilience.spec.ts
+git commit -m "refactor: centralize intentional frontend RPC calls"
+```
+
+---
+
+### Task 2: Standardize user-visible error handling with Refine notifications (M3)
+
+**Files:**
+- Modify: `apps/web-next/src/pages/budgets/create.tsx`
+- Modify: `apps/web-next/src/pages/budgets/edit.tsx`
+- Modify: `apps/web-next/src/pages/settings/index.tsx`
+- Modify: `apps/web-next/src/hooks/usePeriodStats.ts`
+- Modify: `apps/web-next/src/hooks/useChartsData.ts`
+- Modify: `apps/web-next/src/pages/dashboard/useBudgets.ts`
+- Test: `apps/web-next/e2e/tests/settings-rpc-resilience.spec.ts`
+
+- [ ] **Step 1: Extend failing test to assert standardized notification UX**
+
+```ts
+test("reset data RPC failure shows notification", async ({ page }) => {
+  await page.goto("/settings");
+  await page.getByRole("tab", { name: /danger zone/i }).click();
+  await page.getByRole("button", { name: /reset all data/i }).click();
+  await page.getByRole("button", { name: /yes, delete everything/i }).click();
+
+  // Standardized notification text target
+  await expect(page.getByText(/failed to reset data/i)).toBeVisible();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web-next && npm run test:e2e:ci -- e2e/tests/settings-rpc-resilience.spec.ts -g "reset data RPC failure"`  
+Expected: FAIL before notification standardization is in place.
+
+- [ ] **Step 3: Implement minimal notification standardization**
+
+```ts
+// budgets/create.tsx
+import { useNotification } from "@refinedev/core";
+// remove: message import
+const { open } = useNotification();
+
+if (!budgetId) {
+  open?.({
+    type: "error",
+    message: "Failed to create budget",
+    description: "Budget ID was not returned from create mutation.",
+  });
+  throw new Error("Missing budget ID after create");
+}
+
+if (errors.length > 0) {
+  open?.({
+    type: "error",
+    message: "Budget created with link errors",
+    description: errors.join(", "),
+  });
+}
+```
+
+```ts
+// budgets/edit.tsx
+import { useNotification } from "@refinedev/core";
+const { open } = useNotification();
+
+if (!id) {
+  open?.({
+    type: "error",
+    message: "Failed to update budget",
+    description: "Budget ID is missing in edit route.",
+  });
+  throw new Error("Missing budget ID in edit form");
+}
+
+if (errors.length > 0) {
+  open?.({
+    type: "error",
+    message: "Budget saved with relation update errors",
+    description: errors.join(", "),
+  });
+}
+```
+
+```ts
+// settings/index.tsx (replace message.success + inline-only error handling)
+import { useNotification } from "@refinedev/core";
+const { open } = useNotification();
+
+open?.({ type: "success", message: "Upload completed successfully" });
+open?.({
+  type: "error",
+  message: "Failed to upload data",
+  description: err instanceof Error ? err.message : "Upload failed",
+});
+```
+
+```ts
+// usePeriodStats.ts
+const loading =
+  typeQuery.isLoading || categoryQuery.isLoading || prevTypeQuery.isLoading;
+
+return {
+  typeSummary,
+  categorySummary,
+  previousTypeSummary,
+  loading,
+  error: typeQuery.error ?? categoryQuery.error ?? prevTypeQuery.error ?? null,
+};
+```
+
+- [ ] **Step 4: Render hook error states in dashboard components**
+
+```ts
+// PeriodTab.tsx and/or ChartsTab.tsx
+import { Alert } from "antd";
+
+if (stats.error) {
+  return (
+    <Alert
+      type="error"
+      showIcon
+      message="Failed to load statistics"
+      description={stats.error.message}
+    />
+  );
+}
+```
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `cd apps/web-next && npm run test:e2e:ci -- e2e/tests/settings-rpc-resilience.spec.ts`  
+Expected: PASS with visible standardized failure notifications.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add \
+  apps/web-next/src/pages/budgets/create.tsx \
+  apps/web-next/src/pages/budgets/edit.tsx \
+  apps/web-next/src/pages/settings/index.tsx \
+  apps/web-next/src/hooks/usePeriodStats.ts \
+  apps/web-next/src/hooks/useChartsData.ts \
+  apps/web-next/src/pages/dashboard/useBudgets.ts \
+  apps/web-next/e2e/tests/settings-rpc-resilience.spec.ts
+git commit -m "refactor: standardize frontend error handling via refine notifications"
+```
+
+---
+
+### Task 3: Extract shared MonthRangePicker and enforce valid month range (M4)
+
+**Files:**
+- Create: `apps/web-next/src/components/MonthRangePicker.tsx`
+- Modify: `apps/web-next/src/pages/dashboard/components/PeriodTab.tsx`
+- Modify: `apps/web-next/src/pages/dashboard/ChartsTab.tsx`
+- Test: `apps/web-next/e2e/tests/dashboard-month-range.spec.ts`
+
+- [ ] **Step 1: Write failing dashboard range validation test**
+
+```ts
+import { test, expect } from "@playwright/test";
+import { createTestUser, deleteTestUser, loginUser } from "../utils/test-helpers";
+
+test("charts tab blocks invalid month range", async ({ page }) => {
+  const { email, password, userId } = await createTestUser("month-range");
+  try {
+    await loginUser(page, email, password);
+    await page.getByRole("tab", { name: /charts/i }).click();
+    // Will fail until MonthRangePicker + validation is implemented.
+    await expect(page.getByText(/end month must be after start month/i)).toBeVisible();
+  } finally {
+    await deleteTestUser(userId);
+  }
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web-next && npm run test:e2e:ci -- e2e/tests/dashboard-month-range.spec.ts`  
+Expected: FAIL because no invalid-range warning exists yet.
+
+- [ ] **Step 3: Implement MonthRangePicker component**
+
+```tsx
+// apps/web-next/src/components/MonthRangePicker.tsx
+import { Select, Space, Typography } from "antd";
+import { yearOptions, monthOptions } from "../constants/dateOptions";
+
+export interface MonthRangePickerProps {
+  startYear: number;
+  startMonth: number;
+  endYear: number;
+  endMonth: number;
+  onChange: (range: {
+    startYear: number;
+    startMonth: number;
+    endYear: number;
+    endMonth: number;
+  }) => void;
+  singleMonth?: boolean;
+}
+
+export const MonthRangePicker = ({
+  startYear,
+  startMonth,
+  endYear,
+  endMonth,
+  onChange,
+  singleMonth = false,
+}: MonthRangePickerProps) => {
+  const { Text } = Typography;
+  return (
+    <Space wrap align="center">
+      <Text strong>{singleMonth ? "Year:" : "From:"}</Text>
+      <Select value={startYear} options={yearOptions} onChange={(v) => onChange({ startYear: v, startMonth, endYear, endMonth })} style={{ width: 100 }} />
+      <Select value={startMonth} options={monthOptions} onChange={(v) => onChange({ startYear, startMonth: v, endYear, endMonth })} style={{ width: 130 }} />
+      {!singleMonth && (
+        <>
+          <Text strong>To:</Text>
+          <Select value={endYear} options={yearOptions} onChange={(v) => onChange({ startYear, startMonth, endYear: v, endMonth })} style={{ width: 100 }} />
+          <Select value={endMonth} options={monthOptions} onChange={(v) => onChange({ startYear, startMonth, endYear, endMonth: v })} style={{ width: 130 }} />
+        </>
+      )}
+    </Space>
+  );
+};
+```
+
+- [ ] **Step 4: Wire both dashboard views and add invalid-range guard**
+
+```tsx
+// ChartsTab.tsx
+const isInvalidRange =
+  dayjs().year(endYear).month(endMonth).startOf("month").isSameOrBefore(
+    dayjs().year(startYear).month(startMonth).startOf("month")
+  );
+
+{isInvalidRange ? (
+  <Alert
+    type="warning"
+    showIcon
+    message="Invalid date range"
+    description="End month must be after start month."
+  />
+) : (
+  <TrendChart data={trend} currency={currency} />
+)}
+```
+
+```tsx
+// PeriodTab.tsx
+<MonthRangePicker
+  singleMonth
+  startYear={selectedYear}
+  startMonth={selectedMonth}
+  endYear={selectedYear}
+  endMonth={selectedMonth}
+  onChange={({ startYear, startMonth }) => {
+    setSelectedYear(startYear);
+    setSelectedMonth?.(startMonth);
+  }}
+/>;
+```
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `cd apps/web-next && npm run test:e2e:ci -- e2e/tests/dashboard-month-range.spec.ts`  
+Expected: PASS with warning shown and charts hidden for invalid ranges.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add \
+  apps/web-next/src/components/MonthRangePicker.tsx \
+  apps/web-next/src/pages/dashboard/components/PeriodTab.tsx \
+  apps/web-next/src/pages/dashboard/ChartsTab.tsx \
+  apps/web-next/e2e/tests/dashboard-month-range.spec.ts
+git commit -m "feat: add shared month range picker with validation"
+```
+
+---
+
+### Task 4: Regression pass for remaining architecture items
+
+**Files:**
+- Test: `apps/web-next/e2e/tests/dashboard.spec.ts`
+- Test: `apps/web-next/e2e/tests/settings-tabs.spec.ts`
+- Test: `apps/web-next/e2e/tests/budgets.spec.ts`
+- Test: `apps/web-next/e2e/tests/transactions.spec.ts`
+
+- [ ] **Step 1: Add/adjust assertions for refactored selectors and notifications**
+
+```ts
+// dashboard.spec.ts additions
+await expect(page.getByText(/from:/i)).toBeVisible();
+await expect(page.getByText(/to:/i)).toBeVisible();
+```
+
+```ts
+// settings-tabs.spec.ts additions
+await expect(page.getByText(/failed to upload data/i)).not.toBeVisible();
+```
+
+- [ ] **Step 2: Run focused suite**
+
+Run: `cd apps/web-next && npm run test:e2e:ci -- e2e/tests/dashboard.spec.ts e2e/tests/settings-tabs.spec.ts e2e/tests/budgets.spec.ts e2e/tests/transactions.spec.ts`  
+Expected: PASS.
+
+- [ ] **Step 3: Run quality checks**
+
+Run: `cd apps/web-next && npm run lint && npm run check-types`  
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web-next/e2e/tests/dashboard.spec.ts apps/web-next/e2e/tests/settings-tabs.spec.ts
+git commit -m "test: cover remaining frontend architecture refactors"
+```
+
+---
+
+## Dependency Order
+
+1. Task 1 (RPC wrappers) → prerequisite for consistent call sites in Task 2  
+2. Task 2 (error handling normalization)  
+3. Task 3 (shared picker + validation)  
+4. Task 4 (regression and final checks)
+
+## Notes
+
+- Keep changes DRY: do not duplicate RPC names or date-selector rendering logic.
+- Keep YAGNI: only wrap RPCs currently used in frontend (`bulk_upload_data`, `reset_user_data`, `create_transaction_with_tags`, `update_transaction_with_tags`).
+- Avoid broad catch/silent failure paths; always surface an actionable message.
+- Prefer small commits by task so any regression is easy to isolate.

--- a/docs/superpowers/plans/2026-05-13-e2e-failure-stabilization.md
+++ b/docs/superpowers/plans/2026-05-13-e2e-failure-stabilization.md
@@ -1,0 +1,51 @@
+# E2E Failure Stabilization Plan (dashboard-month-range + transactions)
+
+## Problem statement
+`npm run test:e2e:ci` currently fails with 5 timeouts. All failures are blocked on `page.waitForLoadState("networkidle")` (30s timeout), primarily in `e2e/tests/transactions.spec.ts` plus one in `e2e/tests/dashboard-month-range.spec.ts`.
+
+## Current state summary
+- `waitForFormReady()` in `apps/web-next/e2e/utils/test-helpers.ts` only waits for `aria-busy="false"` on edit forms.
+- Failing tests add an extra `networkidle` wait after form readiness / tab switches.
+- The non-failing edit tests (`categories`, `tags`, `bank-accounts`) rely on `waitForFormReady()` and do **not** use `networkidle`.
+- Chart tests depend on async loading from `useChartsData(...)`, but `networkidle` is a weak signal for readiness in this app.
+
+## Proposed approach
+Replace brittle global-idle waits with deterministic, user-visible readiness checks in the failing tests. Keep scope focused on e2e test reliability first; only touch app code if a deterministic test-only fix is not possible.
+
+## Plan tasks
+
+### 1) Use Playwright CLI to inspect failing UI transitions before refactor
+- **Tools:** `playwright-cli` (or `npx playwright-cli` fallback)
+- Reproduce failing flows interactively (transactions edit + dashboard charts tab) and inspect:
+  - whether dropdown overlays detach/re-render during interactions
+  - whether chart area has stable UI readiness signals
+  - whether network-idle is misleading versus actual user-visible readiness
+- Capture findings to drive helper/assertion choices in test refactor steps.
+
+### 2) Add deterministic wait helpers for transactions/dashboard flows
+- **Files:** `apps/web-next/e2e/utils/test-helpers.ts`
+- Add helpers that wait on UI state relevant to each flow (form ready + expected controls/values visible, or chart/loading-state transitions) instead of page-level `networkidle`.
+- Keep helpers composable so multiple transaction tests can reuse the same synchronization points.
+
+### 3) Refactor failing transaction edit/tag/category tests to use helper-based waits
+- **Files:** `apps/web-next/e2e/tests/transactions.spec.ts`
+- Replace failing `networkidle` calls (edit flow, tag update flow, category-by-type flow) with helper waits.
+- While editing these blocks, align Ant Design Select interactions to visible dropdown-scoped selection where needed to reduce detached-element flakes.
+
+### 4) Refactor dashboard month-range invalid-state test to avoid `networkidle`
+- **Files:** `apps/web-next/e2e/tests/dashboard-month-range.spec.ts`
+- Remove initial `networkidle` wait on Charts tab open.
+- Use explicit assertions for “chart rendered / loading complete / warning visible” and preserve existing network-request suppression assertion semantics.
+
+### 5) Validate with targeted reruns, then full suite
+- **Commands:**  
+  - (Optional, for diagnosis while refactoring) `playwright-cli` session commands to verify element visibility/locators in the live app
+  - `cd apps/web-next && npm run test:e2e:ci -- e2e/tests/dashboard-month-range.spec.ts`  
+  - `cd apps/web-next && npm run test:e2e:ci -- e2e/tests/transactions.spec.ts`  
+  - `cd apps/web-next && npm run test:e2e:ci`
+- Confirm failing scenarios are stable and no regressions introduced.
+
+## Notes / guardrails
+- Prefer semantic Playwright locators (`getByRole`, `expect(...).toBeVisible`) and app-state assertions over timing/network heuristics.
+- Scope is **test-only fixes first** (no production code changes unless explicitly re-approved later).
+- Keep this effort scoped to the reported 5 failures; only broaden if reruns reveal tightly coupled flakes.


### PR DESCRIPTION
## Why
E2E coverage on this branch included flaky failures around UI synchronization and intermittent test-user setup failures in budget tests. This change set improves stability so CI runs are deterministic and setup/teardown failures do not mask root errors.

## What Changed
- Files or areas updated:
  - `apps/web-next/e2e/tests/transactions.spec.ts`
  - `apps/web-next/e2e/tests/dashboard-month-range.spec.ts`
  - `apps/web-next/e2e/tests/budgets.spec.ts`
  - `apps/web-next/e2e/utils/test-helpers.ts`
  - Existing branch changes to bulk upload/data reset/settings resilience tests and plan docs are also included in this branch history.
- New functionality added:
  - Reusable helper utilities for deterministic readiness checks and visible Ant Design dropdown selection in e2e tests.
  - Retry/backoff for transient Supabase Auth `createUser` failures in e2e setup.
- Existing behavior changed:
  - Replaced brittle `networkidle` synchronization in affected tests with explicit UI-state assertions.
  - Budget test teardown/setup is now guarded when `beforeAll` fails to avoid cascade errors.

## Key Decisions
- Decision:
  - Use condition-based waits and scoped dropdown locators instead of page-level network-idle waits.
- Reasoning:
  - `networkidle` was flaky for app behavior with background requests and async UI transitions.
- Alternatives considered:
  - Increasing timeouts/retries only; rejected as it treats symptoms, not synchronization root cause.

## How This Affects the System
- User-facing changes:
  - None (test-only changes).
- API changes:
  - None.
- Performance implications:
  - None in production.
- Database changes:
  - None.
- Breaking changes:
  - None.

## Testing
- New tests added:
  - No brand-new spec files; existing e2e tests were refactored/hardened.
- Existing tests status:
  - `npm run test:e2e:ci -- e2e/tests/budgets.spec.ts` passed.
  - `npm run test:e2e:ci` passed (80/80).
- Manual testing performed:
  - N/A (automated e2e focus).
- Edge cases tested:
  - Transient auth setup failures and setup-failure teardown behavior in budget specs.
  - Dropdown interaction stability and chart/edit form readiness timing.
- Test files modified or added:
  - `apps/web-next/e2e/tests/transactions.spec.ts`
  - `apps/web-next/e2e/tests/dashboard-month-range.spec.ts`
  - `apps/web-next/e2e/tests/budgets.spec.ts`
  - `apps/web-next/e2e/utils/test-helpers.ts`