### PR TITLE
docs: mark completed plans as done

### DIFF
--- a/docs/superpowers/plans/2026-05-10-frontend-architecture-remaining-items.md
+++ b/docs/superpowers/plans/2026-05-10-frontend-architecture-remaining-items.md
@@ -1,5 +1,7 @@
 # Frontend Architecture Remaining Items (M3, M4, L3) Implementation Plan
 
+**Status:** Done
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Complete the remaining frontend architecture work by standardizing error handling, extracting a shared month-range picker, and documenting/typing intentional direct Supabase RPC usage.

--- a/docs/superpowers/plans/2026-05-13-e2e-failure-stabilization.md
+++ b/docs/superpowers/plans/2026-05-13-e2e-failure-stabilization.md
@@ -1,5 +1,7 @@
 # E2E Failure Stabilization Plan (dashboard-month-range + transactions)
 
+**Status:** Done
+
 ## Problem statement
 `npm run test:e2e:ci` currently fails with 5 timeouts. All failures are blocked on `page.waitForLoadState("networkidle")` (30s timeout), primarily in `e2e/tests/transactions.spec.ts` plus one in `e2e/tests/dashboard-month-range.spec.ts`.
 
@@ -49,3 +51,7 @@ Replace brittle global-idle waits with deterministic, user-visible readiness che
 - Prefer semantic Playwright locators (`getByRole`, `expect(...).toBeVisible`) and app-state assertions over timing/network heuristics.
 - Scope is **test-only fixes first** (no production code changes unless explicitly re-approved later).
 - Keep this effort scoped to the reported 5 failures; only broaden if reruns reveal tightly coupled flakes.
+
+## Follow-up hardening completed
+- Added transient Supabase Auth retry/backoff in `apps/web-next/e2e/utils/test-helpers.ts` so `createTestUser()` can recover from occasional 500/unexpected_failure responses.
+- Guarded `apps/web-next/e2e/tests/budgets.spec.ts` teardown/setup so `afterAll` does not cascade when `beforeAll` fails to initialize the suite user.


### PR DESCRIPTION
## Why
Two completed implementation plans were still marked as in-progress. This updates the plan docs to reflect the actual state of the work so the repository record stays accurate.

## What Changed
- Files or areas updated:
  - `docs/superpowers/plans/2026-05-10-frontend-architecture-remaining-items.md`
  - `docs/superpowers/plans/2026-05-13-e2e-failure-stabilization.md`
- New functionality added:
  - None.
- Existing behavior changed:
  - Both plan docs now show `Status: Done`.

## Key Decisions
- Decision:
  - Keep this as a docs-only follow-up instead of changing any implementation code.
- Reasoning:
  - The underlying work is already complete; only the plan metadata needed updating.
- Alternatives considered:
  - Leaving the plans unchanged; rejected because it misrepresents completion.

## How This Affects the System
- User-facing changes:
  - None.
- API changes:
  - None.
- Performance implications:
  - None.
- Database changes:
  - None.
- Breaking changes:
  - None.

## Testing
- New tests added:
  - None.
- Existing tests status:
  - Not run (docs-only change).
- Manual testing performed:
  - None.
- Edge cases tested:
  - None.
- Test files modified or added:
  - None.
