### PR TITLE
Add quiet-ledger icon favicon

### DIFF
--- a/apps/web-next/index.html
+++ b/apps/web-next/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="/favicon.ico" />
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta

--- a/apps/web-next/public/favicon.svg
+++ b/apps/web-next/public/favicon.svg
@@ -1,0 +1,10 @@
+<svg
+  width="32"
+  height="32"
+  viewBox="0 0 32 32"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <circle cx="16" cy="16" r="12" fill="#1B6FD8" />
+  <circle cx="12" cy="11" r="2.2" fill="white" />
+</svg>

--- a/apps/web-next/src/assets/logo-mark.svg
+++ b/apps/web-next/src/assets/logo-mark.svg
@@ -1,0 +1,10 @@
+<svg
+  width="32"
+  height="32"
+  viewBox="0 0 32 32"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <circle cx="16" cy="16" r="12" fill="#1B6FD8" />
+  <circle cx="12" cy="11" r="2.2" fill="white" />
+</svg>

--- a/apps/web-next/src/components/title/index.tsx
+++ b/apps/web-next/src/components/title/index.tsx
@@ -1,30 +1,26 @@
 import React from "react";
 import { theme } from "antd";
 import { Link } from "@refinedev/core";
+import logoMarkUrl from "../../assets/logo-mark.svg";
+
 export const ProjectTitle: React.FC = () => {
   const { token } = theme.useToken();
-  const textColor = token.colorTextHeading;
 
   return (
-    <Link to="/">
-      <svg
-        width="140"
-        height="32"
-        viewBox="0 0 140 32"
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <text
-          x="0"
-          y="24"
-          fontFamily="Arial, Helvetica, sans-serif"
-          fontSize="24"
-          fontWeight="bold"
-          fill={textColor}
-        >
-          MoneyLens
-        </text>
-      </svg>
+    <Link
+      to="/"
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 12,
+        color: token.colorTextHeading,
+        textDecoration: "none",
+      }}
+    >
+      <img src={logoMarkUrl} alt="" aria-hidden width={32} height={32} />
+      <span style={{ fontSize: 18, fontWeight: 700, letterSpacing: "-0.03em" }}>
+        MoneyLens
+      </span>
     </Link>
   );
 };


### PR DESCRIPTION
## Why
Use the Quiet Ledger icon as the app favicon and title mark.

## What Changed
- Added the Quiet Ledger icon asset to `apps/web-next/src/assets/logo-mark.svg`
- Wired the icon into the app shell title in `apps/web-next/src/components/title/index.tsx`
- Added `apps/web-next/public/favicon.svg`
- Updated `apps/web-next/index.html` to load the SVG favicon

## Testing
- Not run for this final favicon-only change