### PR TITLE
docs: add parent categories closure-table spec and plan

### DIFF
--- a/docs/superpowers/plans/2026-05-30-quiet-ledger.md
+++ b/docs/superpowers/plans/2026-05-30-quiet-ledger.md
@@ -1,5 +1,8 @@
 # Quiet Ledger Implementation Plan
 
+> **Status: ⏸️ PAUSED** — Deferred for later (not the right timing now)  
+> Favicon (#184) merged as interim step. Full visual identity rollout held pending product direction clarity.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Apply the Quiet Ledger visual identity across the app shell, charts, auth pages, and shared brand assets.

--- a/docs/superpowers/plans/2026-05-30-theme-token-extraction.md
+++ b/docs/superpowers/plans/2026-05-30-theme-token-extraction.md
@@ -1,5 +1,8 @@
 # Theme Token Extraction Implementation Plan
 
+> **Status: ✅ COMPLETE — PR [#185](https://github.com/iguliaev/moneylens/pull/185) · 2026-05-31**  
+> All 4 tasks implemented with CSS variable fallbacks, pre-paint mode application, and comprehensive e2e coverage.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Centralize light/dark theme values into a shared token layer and move app-wide typography into the Vite/Ant Design shell without changing the product's visual identity.

--- a/docs/superpowers/plans/2026-06-01-parent-categories-closure-table.md
+++ b/docs/superpowers/plans/2026-06-01-parent-categories-closure-table.md
@@ -1,0 +1,493 @@
+# Parent Categories (Closure Table) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add parent/child categories with closure-table rollups, keep transactions leaf-only, and preserve bulk upload behavior with leaf category names.
+
+**Architecture:** Extend the Supabase schema with a `category_hierarchy` closure table and DB-side invariants for 2-level hierarchy. Update category and transaction UI flows to expose hierarchy while enforcing leaf-only assignment. Keep budgets unchanged; adjust reporting and upload validation paths to remain compatible with hierarchy-aware categories.
+
+**Tech Stack:** Supabase/PostgreSQL (migrations + pgTAP), React 19 + Refine + Ant Design 5, Playwright E2E
+
+---
+
+## File Structure and Responsibilities
+
+- **Create** `supabase/migrations/20260601210000_add_category_hierarchy.sql`
+  - Adds closure table, indexes, constraints/triggers, and helper SQL functions.
+- **Create** `supabase/tests/category_hierarchy_test.sql`
+  - pgTAP coverage for hierarchy invariants and rollup behavior.
+- **Modify** `supabase/migrations/20260201164000_baseline_from_schemas.sql` (if repository policy requires baseline sync)
+  - Mirror latest schema/function definitions used by tests/tooling.
+- **Modify** `supabase/tests/bulk_insert_test.sql`
+  - Add parent-category rejection for bulk transaction import.
+- **Modify** `supabase/tests/bulk_upload_entities_test.sql`
+  - Add integration assertion that parent category names are rejected in transaction rows.
+- **Modify** `apps/web-next/src/types/database.types.ts`
+  - Regenerated types including hierarchy objects and updated function signatures.
+- **Create** `apps/web-next/src/utility/categoryHierarchy.ts`
+  - Shared helpers (`isLeafCategory`, tree flattening/formatting).
+- **Modify** `apps/web-next/src/pages/categories/create.tsx`
+  - Optional parent selector filtered by type.
+- **Modify** `apps/web-next/src/pages/categories/edit.tsx`
+  - Parent selector with self-exclusion and type compatibility.
+- **Modify** `apps/web-next/src/pages/categories/list.tsx`
+  - Hierarchical rendering (parent with child rows/indent).
+- **Modify** `apps/web-next/src/pages/categories/show.tsx`
+  - Display parent metadata.
+- **Modify** `apps/web-next/src/pages/transactions/create.tsx`
+  - Category options restricted to leaves.
+- **Modify** `apps/web-next/src/pages/transactions/edit.tsx`
+  - Category options restricted to leaves.
+- **Modify** `apps/web-next/src/utility/rpc.ts`
+  - Keep bulk upload payload typing compatible (leaf category names only).
+- **Modify** `apps/web-next/e2e/tests/categories.spec.ts`
+  - Add parent/child creation and hierarchy display tests.
+- **Modify** `apps/web-next/e2e/tests/transactions.spec.ts`
+  - Add leaf-only category selection tests.
+- **Modify** `apps/web-next/e2e/tests/bulk-upload.spec.ts`
+  - Add parent-category upload rejection coverage.
+
+---
+
+### Task 1: Add schema primitives for category hierarchy
+
+**Files:**
+- Create: `supabase/migrations/20260601210000_add_category_hierarchy.sql`
+- Test: `supabase/tests/category_hierarchy_test.sql`
+
+- [ ] **Step 1: Write failing pgTAP tests for hierarchy table + invariants**
+
+```sql
+begin;
+create extension if not exists pgtap with schema extensions;
+select plan(8);
+
+select tests.create_supabase_user('hier_user@test.com');
+select tests.authenticate_as('hier_user@test.com');
+
+insert into public.categories (id, type, name) values
+  (gen_random_uuid(), 'spend', 'Utilities'),
+  (gen_random_uuid(), 'spend', 'Electricity');
+
+-- Fails before implementation: relation missing
+select has_table('public', 'category_hierarchy', 'category_hierarchy table exists');
+select col_is_pk('public', 'category_hierarchy', 'ancestor_id', 'ancestor in PK');
+select col_is_pk('public', 'category_hierarchy', 'descendant_id', 'descendant in PK');
+
+select * from finish();
+rollback;
+```
+
+- [ ] **Step 2: Run pgTAP test to verify failure**
+
+Run: `supabase test db -- --include category_hierarchy_test.sql`  
+Expected: FAIL with missing `category_hierarchy` objects.
+
+- [ ] **Step 3: Implement migration for closure table + indexes**
+
+```sql
+create table if not exists public.category_hierarchy (
+  ancestor_id uuid not null references public.categories(id) on delete cascade,
+  descendant_id uuid not null references public.categories(id) on delete cascade,
+  depth int not null check (depth >= 0 and depth <= 1),
+  primary key (ancestor_id, descendant_id)
+);
+
+create index if not exists idx_category_hierarchy_ancestor_depth
+  on public.category_hierarchy(ancestor_id, depth);
+
+create index if not exists idx_category_hierarchy_descendant_depth
+  on public.category_hierarchy(descendant_id, depth);
+```
+
+- [ ] **Step 4: Add hierarchy maintenance trigger helpers**
+
+```sql
+alter table public.categories add column if not exists parent_id uuid null
+  references public.categories(id) on delete set null;
+
+create or replace function public.sync_category_hierarchy()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  delete from public.category_hierarchy
+   where descendant_id = new.id and depth = 1;
+
+  insert into public.category_hierarchy (ancestor_id, descendant_id, depth)
+  values (new.id, new.id, 0)
+  on conflict do nothing;
+
+  if new.parent_id is not null then
+    insert into public.category_hierarchy (ancestor_id, descendant_id, depth)
+    values (new.parent_id, new.id, 1)
+    on conflict do nothing;
+  end if;
+
+  return new;
+end;
+$$;
+```
+
+- [ ] **Step 5: Re-run pgTAP and commit**
+
+Run: `supabase test db -- --include category_hierarchy_test.sql`  
+Expected: PASS for table/index/invariant checks.
+
+```bash
+git add supabase/migrations/20260601210000_add_category_hierarchy.sql supabase/tests/category_hierarchy_test.sql
+git commit -m "feat(db): add category hierarchy closure table"
+```
+
+---
+
+### Task 2: Enforce leaf-only and update server-side category resolution
+
+**Files:**
+- Modify: `supabase/migrations/20260601210000_add_category_hierarchy.sql`
+- Modify: `supabase/migrations/20260201164000_baseline_from_schemas.sql`
+- Modify: `supabase/tests/bulk_insert_test.sql`
+- Modify: `supabase/tests/bulk_upload_entities_test.sql`
+
+- [ ] **Step 1: Write failing pgTAP test for parent-name rejection in bulk insert**
+
+```sql
+select throws_ok(
+  $$ select bulk_insert_transactions(
+    '[{"date":"2026-01-01","type":"spend","category":"Utilities","amount":10}]'::jsonb
+  ) $$,
+  'P0001',
+  'Bulk insert failed with 1 error(s)',
+  'Reject parent category names in bulk transactions'
+);
+```
+
+- [ ] **Step 2: Run targeted DB tests to confirm current failure mode**
+
+Run: `supabase test db -- --include bulk_insert_test.sql --include bulk_upload_entities_test.sql`  
+Expected: FAIL because parent categories are currently not distinguished from leaves.
+
+- [ ] **Step 3: Update `bulk_insert_transactions` category lookup to require leaves**
+
+```sql
+select c.id into v_category_id
+from public.categories c
+left join public.category_hierarchy ch
+  on ch.ancestor_id = c.id and ch.depth = 1
+where c.user_id = v_user_id
+  and c.type = v_type
+  and c.name = v_tx->>'category'
+group by c.id
+having count(ch.descendant_id) = 0
+limit 1;
+
+if v_category_id is null then
+  v_errors := v_errors || jsonb_build_object(
+    'index', v_idx,
+    'error', format('Category "%s" not found as leaf for type "%s"', v_tx->>'category', v_type)
+  );
+  continue;
+end if;
+```
+
+- [ ] **Step 4: Add parent/type/depth integrity checks**
+
+```sql
+create or replace function public.validate_category_parent()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare v_parent_type public.transaction_type;
+begin
+  if new.parent_id is null then
+    return new;
+  end if;
+
+  if new.parent_id = new.id then
+    raise exception 'Category cannot be parent of itself';
+  end if;
+
+  select type into v_parent_type from public.categories where id = new.parent_id;
+  if v_parent_type is distinct from new.type then
+    raise exception 'Parent category must have same type';
+  end if;
+
+  return new;
+end;
+$$;
+```
+
+- [ ] **Step 5: Re-run DB tests and commit**
+
+Run: `supabase test db -- --include category_hierarchy_test.sql --include bulk_insert_test.sql --include bulk_upload_entities_test.sql`  
+Expected: PASS.
+
+```bash
+git add supabase/migrations/*.sql supabase/tests/bulk_insert_test.sql supabase/tests/bulk_upload_entities_test.sql
+git commit -m "feat(db): enforce leaf-only category assignment for bulk uploads"
+```
+
+---
+
+### Task 3: Expose hierarchy-aware category data to frontend
+
+**Files:**
+- Modify: `apps/web-next/src/types/database.types.ts`
+- Create: `apps/web-next/src/utility/categoryHierarchy.ts`
+
+- [ ] **Step 1: Write failing type-level usage in helper**
+
+```ts
+// categoryHierarchy.ts (initial failing use)
+import type { Tables } from "../types/database.types";
+type Category = Tables<"categories">;
+
+export const isLeafCategory = (_category: Category): boolean => {
+  throw new Error("not implemented");
+};
+```
+
+- [ ] **Step 2: Run type check to confirm missing shape/functions**
+
+Run: `cd apps/web-next && npm run check-types`  
+Expected: FAIL in helper/consumers until types and helper logic are complete.
+
+- [ ] **Step 3: Regenerate DB types and implement helper**
+
+```bash
+supabase gen types typescript --local > types.gen.ts
+```
+
+```ts
+// apps/web-next/src/utility/categoryHierarchy.ts
+import type { Tables } from "../types/database.types";
+
+export type Category = Tables<"categories"> & {
+  parent?: Pick<Tables<"categories">, "id" | "name"> | null;
+  child_count?: number | null;
+};
+
+export const isLeafCategory = (category: Category): boolean =>
+  Number(category.child_count ?? 0) === 0;
+```
+
+- [ ] **Step 4: Re-run type checks and commit**
+
+Run: `cd apps/web-next && npm run check-types`  
+Expected: PASS.
+
+```bash
+git add apps/web-next/src/types/database.types.ts apps/web-next/src/utility/categoryHierarchy.ts types.gen.ts
+git commit -m "chore(types): add hierarchy-aware category typing"
+```
+
+---
+
+### Task 4: Implement category CRUD/list/show hierarchy UX
+
+**Files:**
+- Modify: `apps/web-next/src/pages/categories/create.tsx`
+- Modify: `apps/web-next/src/pages/categories/edit.tsx`
+- Modify: `apps/web-next/src/pages/categories/list.tsx`
+- Modify: `apps/web-next/src/pages/categories/show.tsx`
+- Test: `apps/web-next/e2e/tests/categories.spec.ts`
+
+- [ ] **Step 1: Add failing E2E for parent-child category flow**
+
+```ts
+test("user can create parent and child categories", async ({ page }) => {
+  // create parent Utilities, then child Electricity with parent selected
+  // assert list renders hierarchy (child indented/linked to parent)
+});
+```
+
+- [ ] **Step 2: Run E2E to observe failure**
+
+Run: `cd apps/web-next && npm run test:e2e:ci -- e2e/tests/categories.spec.ts -g "parent and child"`  
+Expected: FAIL (no parent selector / no hierarchy rendering).
+
+- [ ] **Step 3: Implement parent selector in create/edit forms**
+
+```tsx
+<Form.Item label="Parent Category" name={["parent_id"]}>
+  <Select
+    allowClear
+    options={parentOptions}
+    placeholder="No parent (top-level category)"
+  />
+</Form.Item>
+```
+
+```ts
+const parentOptions = (categories ?? [])
+  .filter((c) => c.type === selectedType && c.id !== currentId)
+  .map((c) => ({ label: c.name, value: c.id }));
+```
+
+- [ ] **Step 4: Implement hierarchy-aware list/show rendering**
+
+```tsx
+<Table.Column
+  dataIndex="name"
+  title="Name"
+  render={(value, record) =>
+    record.parent_id ? <span style={{ paddingLeft: 16 }}>↳ {value}</span> : value
+  }
+/>
+```
+
+```tsx
+<Title level={5}>Parent Category</Title>
+<TextField value={record?.parent?.name ?? "—"} />
+```
+
+- [ ] **Step 5: Re-run E2E + commit**
+
+Run: `cd apps/web-next && npm run test:e2e:ci -- e2e/tests/categories.spec.ts`  
+Expected: PASS.
+
+```bash
+git add apps/web-next/src/pages/categories/*.tsx apps/web-next/e2e/tests/categories.spec.ts
+git commit -m "feat(categories): add parent-child hierarchy UI"
+```
+
+---
+
+### Task 5: Enforce leaf-only category selection in transaction forms
+
+**Files:**
+- Modify: `apps/web-next/src/pages/transactions/create.tsx`
+- Modify: `apps/web-next/src/pages/transactions/edit.tsx`
+- Modify: `apps/web-next/src/utility/categoryHierarchy.ts`
+- Test: `apps/web-next/e2e/tests/transactions.spec.ts`
+
+- [ ] **Step 1: Add failing E2E for selecting parent category in transaction form**
+
+```ts
+test("transaction form shows leaf categories only", async ({ page }) => {
+  // seed parent Utilities + child Electricity
+  // open transaction create, ensure Utilities is not selectable, Electricity is selectable
+});
+```
+
+- [ ] **Step 2: Run test and confirm failure**
+
+Run: `cd apps/web-next && npm run test:e2e:ci -- e2e/tests/transactions.spec.ts -g "leaf categories only"`  
+Expected: FAIL (current list includes all categories).
+
+- [ ] **Step 3: Filter select options to leaves**
+
+```tsx
+const leafCategoryOptions = (categorySelectProps.options ?? []).filter((opt) =>
+  isLeafCategory(opt as unknown as Category)
+);
+
+<Select {...categorySelectProps} options={leafCategoryOptions} />
+```
+
+- [ ] **Step 4: Run E2E and commit**
+
+Run: `cd apps/web-next && npm run test:e2e:ci -- e2e/tests/transactions.spec.ts -g "leaf categories only"`  
+Expected: PASS.
+
+```bash
+git add apps/web-next/src/pages/transactions/create.tsx apps/web-next/src/pages/transactions/edit.tsx apps/web-next/src/utility/categoryHierarchy.ts apps/web-next/e2e/tests/transactions.spec.ts
+git commit -m "feat(transactions): restrict category selection to leaves"
+```
+
+---
+
+### Task 6: Preserve and verify bulk upload compatibility
+
+**Files:**
+- Modify: `apps/web-next/e2e/tests/bulk-upload.spec.ts`
+- Modify: `supabase/tests/bulk_insert_test.sql`
+- Modify: `supabase/tests/bulk_upload_entities_test.sql`
+
+- [ ] **Step 1: Add failing tests for parent-category upload rejection**
+
+```ts
+test("bulk upload rejects transaction rows referencing parent categories", async ({ page }) => {
+  // upload fixture where transaction.category points to parent
+  // expect error alert, no partial transaction insert
+});
+```
+
+```sql
+select throws_like(
+  $$ select bulk_upload_data(jsonb_build_object(
+      'transactions', '[{"date":"2026-01-01","type":"spend","amount":"20.00","category":"Utilities"}]'::jsonb
+    )) $$,
+  '%Category "Utilities" not found as leaf%',
+  'bulk upload rejects parent category names'
+);
+```
+
+- [ ] **Step 2: Run targeted tests to confirm failures first**
+
+Run: `supabase test db -- --include bulk_insert_test.sql --include bulk_upload_entities_test.sql`  
+Expected: FAIL before server logic update is complete.
+
+Run: `cd apps/web-next && npm run test:e2e:ci -- e2e/tests/bulk-upload.spec.ts -g "parent categories"`  
+Expected: FAIL before UI assertions align.
+
+- [ ] **Step 3: Align errors/messages and fixtures with new behavior**
+
+```json
+{
+  "transactions": [
+    {
+      "date": "2026-01-01",
+      "type": "spend",
+      "amount": 20,
+      "category": "Utilities"
+    }
+  ]
+}
+```
+
+- [ ] **Step 4: Re-run DB + E2E tests and commit**
+
+Run: `supabase test db -- --include bulk_insert_test.sql --include bulk_upload_entities_test.sql`  
+Expected: PASS.
+
+Run: `cd apps/web-next && npm run test:e2e:ci -- e2e/tests/bulk-upload.spec.ts`  
+Expected: PASS.
+
+```bash
+git add supabase/tests/bulk_insert_test.sql supabase/tests/bulk_upload_entities_test.sql apps/web-next/e2e/tests/bulk-upload.spec.ts
+git commit -m "test: cover bulk upload behavior with category hierarchy"
+```
+
+---
+
+### Task 7: Full verification and final integration commit
+
+**Files:**
+- Modify: all touched files from Tasks 1-6
+
+- [ ] **Step 1: Run app checks**
+
+Run: `cd apps/web-next && npm run check-types && npm run lint && npm run build`  
+Expected: all PASS.
+
+- [ ] **Step 2: Run focused E2E suite for touched areas**
+
+Run: `cd apps/web-next && npm run test:e2e:ci -- e2e/tests/categories.spec.ts e2e/tests/transactions.spec.ts e2e/tests/bulk-upload.spec.ts`  
+Expected: PASS.
+
+- [ ] **Step 3: Run DB tests**
+
+Run: `supabase test db -- --include category_hierarchy_test.sql --include bulk_insert_test.sql --include bulk_upload_entities_test.sql`  
+Expected: PASS.
+
+- [ ] **Step 4: Final commit**
+
+```bash
+git add -A
+git commit -m "feat: add parent category hierarchy with leaf-only transaction assignment"
+```

--- a/docs/superpowers/specs/2026-06-01-parent-categories-closure-table-design.md
+++ b/docs/superpowers/specs/2026-06-01-parent-categories-closure-table-design.md
@@ -1,0 +1,149 @@
+# Parent Categories via Closure Table (Design Spec)
+
+Date: 2026-06-01  
+Status: Approved for design phase
+
+## 1. Goal
+
+Introduce parent categories so users can organize categories hierarchically and get rollup reporting totals, while keeping transaction categorization strict and clean:
+
+- Transactions are assigned to **leaf categories only**
+- Category hierarchy is limited to **2 levels** in this phase (Parent -> Child)
+- Budget behavior remains **unchanged** in this phase
+
+## 2. Scope
+
+In scope:
+
+- Category hierarchy data model using closure table
+- Category create/edit/delete behavior with hierarchy integrity
+- Category list and transaction category picker updates
+- Parent rollup reporting queries
+- Database and UI test coverage for new behavior
+
+Out of scope:
+
+- Parent-aware budget links/aggregation
+- Automatic migration/renaming of existing slash-style names
+- Deep hierarchy UX beyond two levels
+
+## 3. Chosen Approach
+
+Chosen: **Closure table** (`category_hierarchy`) with explicit ancestor/descendant links.
+
+Rationale:
+
+- Strong model for rollups and future deeper hierarchies
+- Simple read path for parent aggregation
+- Clear integrity boundaries between category records and hierarchy graph
+
+## 4. Data Model
+
+### 4.1 Categories table
+
+`public.categories` remains the source of category records.
+
+### 4.2 New hierarchy table
+
+Add `public.category_hierarchy`:
+
+- `ancestor_id uuid not null references public.categories(id) on delete cascade`
+- `descendant_id uuid not null references public.categories(id) on delete cascade`
+- `depth int not null` (`0` for self, `1` for direct child in this phase)
+- Primary key: `(ancestor_id, descendant_id)`
+- Indexes:
+  - `(ancestor_id, depth)`
+  - `(descendant_id, depth)`
+
+### 4.3 Invariants
+
+- Every category has self-link row: `(id, id, 0)`
+- Parent-child relation adds row: `(parent_id, child_id, 1)`
+- No cycles
+- Max depth is 2 levels in this phase
+
+## 5. Write Operations and Integrity
+
+### 5.1 Create category
+
+1. Insert into `categories`
+2. Insert self-link into `category_hierarchy`
+3. If parent provided:
+   - Validate parent is valid and not self
+   - Validate depth constraint (result remains <= 2)
+   - Insert parent-child link row
+
+### 5.2 Update parent
+
+When setting/changing parent:
+
+1. Validate no cycle
+2. Validate resulting depth <= 2
+3. Rebuild hierarchy links for target category (for two-level model this is direct and bounded)
+
+### 5.3 Delete behavior
+
+- Block deleting a parent that still has child categories, unless children are reassigned or detached first
+- Cascade removes hierarchy rows for deleted category
+
+## 6. Transaction Categorization
+
+Transactions remain single-category (`category_id`) and **leaf-only**:
+
+- Category picker must only allow categories with no depth-1 descendants
+- Validation enforces selected category is leaf at write time
+
+## 7. Reporting and Rollups
+
+Parent totals are computed by joining through closure table:
+
+- For parent `P`, aggregate transactions where
+  `transactions.category_id = category_hierarchy.descendant_id`
+  and `category_hierarchy.ancestor_id = P`
+
+This supports:
+
+- Parent totals (e.g., `Utilities`)
+- Child breakdown (e.g., `Electricity`, `Water`)
+
+## 8. UI Changes
+
+### 8.1 Category pages
+
+- Create/Edit: optional parent selection
+- List/Show: present hierarchy clearly (grouped/indented)
+
+### 8.2 Transaction pages
+
+- Category selector filtered to leaves only
+
+## 9. Budgets (Explicit Non-Goal in This Phase)
+
+Budget logic remains as-is, linking directly to category IDs without parent expansion.
+
+## 10. Testing Strategy
+
+Database tests:
+
+- Self-link creation
+- Parent-child link creation
+- Cycle prevention
+- Max-depth enforcement
+- Parent rollup correctness
+
+UI/E2E tests:
+
+- Assign parent to category in create/edit flows
+- Transaction category picker excludes parent categories
+- Reporting shows parent rollup with child breakdown
+
+## 11. Risks and Mitigations
+
+- Risk: hierarchy corruption from partial writes  
+  Mitigation: perform hierarchy updates in transactional functions/RPCs
+
+- Risk: user confusion assigning transactions to parents  
+  Mitigation: leaf-only picker + explicit validation error
+
+- Risk: future budget expectations for parent behavior  
+  Mitigation: document phase boundary and schedule budget enhancement separately

--- a/docs/superpowers/specs/2026-06-01-parent-categories-closure-table-design.md
+++ b/docs/superpowers/specs/2026-06-01-parent-categories-closure-table-design.md
@@ -19,6 +19,7 @@ In scope:
 - Category create/edit/delete behavior with hierarchy integrity
 - Category list and transaction category picker updates
 - Parent rollup reporting queries
+- Bulk upload compatibility with hierarchy-aware categories
 - Database and UI test coverage for new behavior
 
 Out of scope:
@@ -93,6 +94,15 @@ Transactions remain single-category (`category_id`) and **leaf-only**:
 - Category picker must only allow categories with no depth-1 descendants
 - Validation enforces selected category is leaf at write time
 
+### 6.1 Bulk upload behavior
+
+Existing bulk upload functionality must be preserved and remain operational with hierarchy support:
+
+- Uploaded rows must map category using **leaf category name only**
+- If a category name resolves to a parent (non-leaf), the row is rejected with a clear validation error
+- If a category name is unknown, the row is rejected using existing invalid-category handling
+- No parent/child path syntax is required in this phase
+
 ## 7. Reporting and Rollups
 
 Parent totals are computed by joining through closure table:
@@ -136,6 +146,7 @@ UI/E2E tests:
 - Assign parent to category in create/edit flows
 - Transaction category picker excludes parent categories
 - Reporting shows parent rollup with child breakdown
+- Bulk upload accepts valid leaf category names and rejects parent category names
 
 ## 11. Risks and Mitigations
 


### PR DESCRIPTION
## Why
Parent-category hierarchy was discussed and designed, but we needed a concrete, reviewable spec plus an execution-ready implementation plan. This PR captures those artifacts so implementation can proceed with explicit constraints (leaf-only transaction assignment, 2-level hierarchy in phase 1, and bulk-upload compatibility).

## What Changed
- Files or areas updated:
  - Added `docs/superpowers/specs/2026-06-01-parent-categories-closure-table-design.md`
  - Added `docs/superpowers/plans/2026-06-01-parent-categories-closure-table.md`
  - Includes existing branch docs updates to quiet-ledger/theme-token plans
- New functionality added:
  - No runtime functionality; documentation/specification only
- Existing behavior changed:
  - None in application code

## Key Decisions
- Decision:
  - Use closure-table model for parent categories in the design
  - Keep leaf-only transaction assignment
  - Keep budgets unchanged in phase 1
  - Preserve bulk upload via leaf-category-name mapping
- Reasoning:
  - Balances future hierarchy flexibility with a controlled first implementation scope
- Alternatives considered:
  - Adjacency-only and adjacency+denormalized approaches

## How This Affects the System
- User-facing changes:
  - None yet (planning/design artifacts only)
- API changes:
  - None
- Performance implications:
  - None in current runtime
- Database changes:
  - None in this PR (spec/plan only)
- Breaking changes:
  - None

## Testing
- New tests added:
  - None (plan includes future test tasks)
- Existing tests status:
  - Not changed in this PR
- Manual testing performed:
  - Not applicable
- Edge cases tested:
  - Not applicable
- Test files modified or added:
  - None