### PR TITLE
chore: enforce migration-only rule for database schema changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,11 +161,22 @@ supabase db pull
 
 ## Database Schema Guidelines
 
+### ⚠️ Migration-Only Rule — CRITICAL
+
+**NEVER modify existing files in `supabase/migrations/`.** Every schema change — table creation, column addition/removal/rename, index changes, RLS policy changes, function updates — **MUST go through a new migration file.**
+
+The workflow is always:
+1. `supabase migration new <descriptive_name>` — creates a new timestamped file
+2. Write your SQL changes in that new file
+3. Never touch previously committed migration files
+
+Editing existing migrations breaks the audit trail and will corrupt any environment that has already applied them.
+
 ### Creating Migrations
 
 1. Create migration: `supabase migration new my_feature`
 2. Edit the generated SQL file in `supabase/migrations/`
-3. Apply locally: `supabase dmigration up`
+3. Apply locally: `supabase migration up`
 4. Test with: `supabase test db`
 5. Update seeds if needed in `supabase/seeds/`
 


### PR DESCRIPTION
## Why

Coding agents and contributors need an unambiguous rule: schema changes must never be made by editing existing migration files. Without this, agents can silently corrupt already-applied environments by modifying history.

## What Changed

- Files or areas updated: AGENTS.md
- New functionality added: ⚠️ Migration-Only Rule section under Database Schema Guidelines
- Existing behavior changed: Clarified that existing migration files must NEVER be modified

## Key Decisions

- Decision: Added a prominent ⚠️ warning block before the migration workflow steps
- Reasoning: The rule needs to be unmissable — an agent scanning for 'how do I change the schema' will hit this before the workflow steps
- Alternatives considered: Inline note only (too easy to miss)

## How This Affects the System

- User-facing changes: None
- Database changes: None (docs only)
- Breaking changes: None

## Testing

- Manual testing performed: Read through AGENTS.md to verify clarity
- Also fixed pre-existing typo: `supabase dmigration up` → `supabase migration up`