### PR TITLE
fix(transactions): keep filters on pagination and reset on type switch

### DIFF
--- a/apps/web-next/e2e/tests/transactions.spec.ts
+++ b/apps/web-next/e2e/tests/transactions.spec.ts
@@ -613,6 +613,250 @@ test.describe("Transactions", () => {
     await expect(page.getByText("low-amount")).not.toBeVisible();
   });
 
+  test("category filter persists when moving to page 2", async ({ page }) => {
+    const ts = Date.now();
+    const now = new Date().toISOString();
+    const otherCategoryName = `Other Spend ${ts}`;
+    const otherNote = `persist-other-${ts}`;
+    let otherCategoryId: string | undefined;
+
+    try {
+      const { data: groceriesCategory, error: groceriesCategoryError } =
+        await supabaseAdmin
+          .from("categories")
+          .select("id")
+          .eq("user_id", testUser.userId)
+          .eq("type", "spend")
+          .eq("name", "Groceries")
+          .single();
+      if (groceriesCategoryError || !groceriesCategory?.id) {
+        throw new Error(
+          `Failed to resolve Groceries category: ${
+            groceriesCategoryError?.message ?? "missing category id"
+          }`
+        );
+      }
+
+      const { data: mainAccount, error: mainAccountError } = await supabaseAdmin
+        .from("bank_accounts")
+        .select("id")
+        .eq("user_id", testUser.userId)
+        .eq("name", "Main Account")
+        .single();
+      if (mainAccountError || !mainAccount?.id) {
+        throw new Error(
+          `Failed to resolve Main Account: ${
+            mainAccountError?.message ?? "missing bank account id"
+          }`
+        );
+      }
+
+      const { data: otherCategory, error: otherCategoryError } =
+        await supabaseAdmin
+          .from("categories")
+          .insert({
+            user_id: testUser.userId,
+            type: "spend",
+            name: otherCategoryName,
+            description: "category-filter-persistence",
+            created_at: now,
+            updated_at: now,
+          })
+          .select("id")
+          .single();
+      if (otherCategoryError || !otherCategory?.id) {
+        throw new Error(
+          `Failed to create secondary spend category: ${
+            otherCategoryError?.message ?? "missing category id"
+          }`
+        );
+      }
+      otherCategoryId = otherCategory.id;
+
+      const filteredTransactions = Array.from({ length: 11 }).map((_, index) => ({
+        user_id: testUser.userId,
+        date: e2eCurrentMonthDate(15),
+        type: "spend" as const,
+        amount: 10 + index,
+        category: "Groceries",
+        category_id: groceriesCategory.id,
+        bank_account_id: mainAccount.id,
+        notes: `persist-groceries-${ts}-${index + 1}`,
+        created_at: now,
+        updated_at: now,
+      }));
+
+      const { error: transactionsError } = await supabaseAdmin
+        .from("transactions")
+        .insert([
+          ...filteredTransactions,
+          {
+            user_id: testUser.userId,
+            date: e2eCurrentMonthDate(1),
+            type: "spend" as const,
+            amount: 999,
+            category: otherCategoryName,
+            category_id: otherCategory.id,
+            bank_account_id: mainAccount.id,
+            notes: otherNote,
+            created_at: now,
+            updated_at: now,
+          },
+        ]);
+      if (transactionsError) {
+        throw new Error(`Failed to seed transactions: ${transactionsError.message}`);
+      }
+
+      await page.goto(
+        "/transactions?" +
+          "pageSize=10&currentPage=1" +
+          "&sorters[0][field]=date&sorters[0][order]=desc" +
+          "&filters[0][field]=type&filters[0][operator]=eq&filters[0][value]=spend" +
+          `&filters[1][field]=category_id&filters[1][operator]=in&filters[1][value][0]=${groceriesCategory.id}`
+      );
+      await page.waitForLoadState("networkidle");
+
+      await expect(page.getByText(otherNote)).not.toBeVisible();
+
+      const secondPageButton = page
+        .locator(".ant-pagination-item")
+        .filter({ hasText: /^2$/ })
+        .first();
+      await expect(secondPageButton).toBeVisible();
+      await secondPageButton.click();
+      await page.waitForLoadState("networkidle");
+
+      await expect(page).toHaveURL(/category_id/);
+      await expect(
+        page.getByText(new RegExp(`persist-groceries-${ts}-`)).first()
+      ).toBeVisible();
+      await expect(page.getByText(otherNote)).not.toBeVisible();
+    } finally {
+      if (otherCategoryId) {
+        await supabaseAdmin.from("categories").delete().eq("id", otherCategoryId);
+      }
+    }
+  });
+
+  test("switching transaction type clears active list filters", async ({ page }) => {
+    let hasRange416 = false;
+    page.on("response", (response) => {
+      if (
+        response.url().includes("/transactions_with_details") &&
+        response.status() === 416
+      ) {
+        hasRange416 = true;
+      }
+    });
+
+    const { data: groceriesCategory, error: groceriesCategoryError } =
+      await supabaseAdmin
+        .from("categories")
+        .select("id")
+        .eq("user_id", testUser.userId)
+        .eq("type", "spend")
+        .eq("name", "Groceries")
+        .single();
+
+    if (groceriesCategoryError || !groceriesCategory?.id) {
+      throw new Error(
+        `Failed to resolve Groceries category: ${
+          groceriesCategoryError?.message ?? "missing category id"
+        }`
+      );
+    }
+
+    const { data: savingsCategory, error: savingsCategoryError } = await supabaseAdmin
+      .from("categories")
+      .select("id")
+      .eq("user_id", testUser.userId)
+      .eq("type", "save")
+      .eq("name", "Savings")
+      .single();
+
+    if (savingsCategoryError || !savingsCategory?.id) {
+      throw new Error(
+        `Failed to resolve Savings category: ${
+          savingsCategoryError?.message ?? "missing category id"
+        }`
+      );
+    }
+
+    const { data: mainAccount, error: mainAccountError } = await supabaseAdmin
+      .from("bank_accounts")
+      .select("id")
+      .eq("user_id", testUser.userId)
+      .eq("name", "Main Account")
+      .single();
+
+    if (mainAccountError || !mainAccount?.id) {
+      throw new Error(
+        `Failed to resolve Main Account: ${
+          mainAccountError?.message ?? "missing bank account id"
+        }`
+      );
+    }
+
+    const ts = Date.now();
+    const now = new Date().toISOString();
+    const seededSpend = Array.from({ length: 65 }).map((_, index) => ({
+      user_id: testUser.userId,
+      date: e2eCurrentMonthDate(15),
+      type: "spend" as const,
+      amount: 10 + index,
+      category: "Groceries",
+      category_id: groceriesCategory.id,
+      bank_account_id: mainAccount.id,
+      notes: `switch-spend-${ts}-${index + 1}`,
+      created_at: now,
+      updated_at: now,
+    }));
+
+    const { error: transactionsError } = await supabaseAdmin
+      .from("transactions")
+      .insert([
+        ...seededSpend,
+        {
+          user_id: testUser.userId,
+          date: e2eCurrentMonthDate(15),
+          type: "save" as const,
+          amount: 777,
+          category: "Savings",
+          category_id: savingsCategory.id,
+          bank_account_id: mainAccount.id,
+          notes: `switch-save-${ts}`,
+          created_at: now,
+          updated_at: now,
+        },
+      ]);
+    if (transactionsError) {
+      throw new Error(`Failed to seed transactions: ${transactionsError.message}`);
+    }
+
+    await page.goto(
+      "/transactions?" +
+        "pageSize=10&currentPage=7" +
+        "&sorters[0][field]=date&sorters[0][order]=desc" +
+        "&filters[0][field]=type&filters[0][operator]=eq&filters[0][value]=spend" +
+        `&filters[1][field]=category_id&filters[1][operator]=in&filters[1][value][0]=${groceriesCategory.id}`
+    );
+    await page.waitForLoadState("networkidle");
+    await expect(page).toHaveURL(/category_id/);
+    expect(hasRange416).toBeFalsy();
+
+    hasRange416 = false;
+    await page
+      .getByRole("radiogroup", { name: "segmented control" })
+      .getByText(/^save$/i)
+      .click();
+    await page.waitForLoadState("networkidle");
+
+    await expect(page).toHaveURL(/currentPage=1/);
+    await expect(page).not.toHaveURL(/category_id|bank_account_id|tag_ids|amount/);
+    await expect(page.getByText(new RegExp(`switch-save-${ts}`))).toBeVisible();
+    expect(hasRange416).toBeFalsy();
+  });
+
   test("transaction form shows leaf categories only", async ({ page }) => {
     const ts = Date.now();
     const parentName = `e2e-leaf-parent-${ts}`;

--- a/apps/web-next/e2e/tests/transactions.spec.ts
+++ b/apps/web-next/e2e/tests/transactions.spec.ts
@@ -732,6 +732,16 @@ test.describe("Transactions", () => {
       ).toBeVisible();
       await expect(page.getByText(otherNote)).not.toBeVisible();
     } finally {
+      await supabaseAdmin
+        .from("transactions")
+        .delete()
+        .eq("user_id", testUser.userId)
+        .like("notes", `persist-groceries-${ts}-%`);
+      await supabaseAdmin
+        .from("transactions")
+        .delete()
+        .eq("user_id", testUser.userId)
+        .eq("notes", otherNote);
       if (otherCategoryId) {
         await supabaseAdmin.from("categories").delete().eq("id", otherCategoryId);
       }

--- a/apps/web-next/src/pages/transactions/list.tsx
+++ b/apps/web-next/src/pages/transactions/list.tsx
@@ -12,7 +12,6 @@ import {
   getDefaultFilter,
 } from "@refinedev/antd";
 import { Table, Space, Segmented, Select, DatePicker, InputNumber } from "antd";
-import { useState } from "react";
 import dayjs from "dayjs";
 import {
   TRANSACTION_TYPE_LABELS,
@@ -51,26 +50,19 @@ const MultiSelectFilter = ({
 
 export const TransactionList = () => {
   const invalidate = useInvalidate();
-  const [transactionType, setTransactionType] = useState<string>(
-    TRANSACTION_TYPES.SPEND
-  );
 
-  const { tableProps, filters, setFilters } = useTable({
+  const { tableProps, filters, setFilters, setCurrentPage } = useTable({
     syncWithLocation: true,
     resource: "transactions_with_details",
     sorters: {
       initial: [{ field: "date", order: "desc" }],
     },
     filters: {
-      permanent: [
-        {
-          field: "type",
-          operator: "eq",
-          value: transactionType,
-        },
-      ],
+      initial: [{ field: "type", operator: "eq", value: TRANSACTION_TYPES.SPEND }],
     },
   });
+  const transactionType =
+    (getDefaultFilter("type", filters, "eq") as string) ?? TRANSACTION_TYPES.SPEND;
 
   // Category select - filtered by current transaction type
   const { selectProps: categorySelectProps } = useSelect({
@@ -112,7 +104,12 @@ export const TransactionList = () => {
           value: type,
         }))}
         value={transactionType}
-        onChange={(value) => setTransactionType(value as string)}
+        onChange={(value) => {
+          const nextType = value as string;
+          if (nextType === transactionType) return;
+          setCurrentPage(1);
+          setFilters([{ field: "type", operator: "eq", value: nextType }], "replace");
+        }}
       />
       {tableProps.loading && !tableProps.dataSource?.length ? (
         <TableSkeleton columns={7} />
@@ -171,7 +168,7 @@ export const TransactionList = () => {
               />
             </FilterDropdown>
           )}
-          defaultFilteredValue={getDefaultFilter("category_id", filters, "in")}
+          filteredValue={getDefaultFilter("category_id", filters, "in") ?? null}
         />
         <Table.Column
           dataIndex="amount"
@@ -186,7 +183,7 @@ export const TransactionList = () => {
               />
             </FilterDropdown>
           )}
-          defaultFilteredValue={getDefaultFilter("amount", filters, "eq")}
+          filteredValue={getDefaultFilter("amount", filters, "eq") ?? null}
         />
         <Table.Column
           key="tag_ids"
@@ -207,7 +204,7 @@ export const TransactionList = () => {
               />
             </FilterDropdown>
           )}
-          defaultFilteredValue={getDefaultFilter("tag_ids", filters, "in")}
+          filteredValue={getDefaultFilter("tag_ids", filters, "in") ?? null}
         />
         <Table.Column
           key="bank_account_id"
@@ -222,11 +219,11 @@ export const TransactionList = () => {
               />
             </FilterDropdown>
           )}
-          defaultFilteredValue={getDefaultFilter(
+          filteredValue={getDefaultFilter(
             "bank_account_id",
             filters,
             "in"
-          )}
+          ) ?? null}
         />
         <Table.Column
           key="notes"


### PR DESCRIPTION
## Why
Transactions filters were being lost during pagination and users could hit stale pagination/filter state when switching transaction type, leading to invalid list requests (including 416 range errors) and broken UI feedback.

## What Changed
- Files or areas updated:
  - `apps/web-next/src/pages/transactions/list.tsx`
  - `apps/web-next/e2e/tests/transactions.spec.ts`
- New functionality added:
  - Added e2e coverage for category-filter persistence across pagination.
  - Added e2e coverage for clearing active filters and resetting page on transaction type switch.
- Existing behavior changed:
  - Table filters (category/amount/tags/bank account) are controlled via `filteredValue` to persist correctly.
  - Transaction type now derives from synced table filters.
  - Type switch resets to page 1 and replaces filters with only the selected type.

## Key Decisions
- Decision:
  - Use `useTable` synced filter state as the single source of truth for transaction type and table filters.
- Reasoning:
  - Prevents drift between local UI state and URL/query state while keeping pagination/filter updates consistent.
- Alternatives considered:
  - Local `useState` for type with permanent filter updates; rejected due to race/state desync risk with synced pagination/filter params.

## How This Affects the System
- User-facing changes:
  - Filters persist when paginating.
  - Switching Spend/Earn/Save clears incompatible filters and resets pagination safely.
- API changes:
  - None.
- Performance implications:
  - No material impact.
- Database changes:
  - None.
- Breaking changes:
  - None.

## Testing
- New tests added:
  - `Transactions › category filter persists when moving to page 2`
  - `Transactions › switching transaction type clears active list filters`
- Existing tests status:
  - Related amount-range filter test still passes.
- Manual testing performed:
  - Through Playwright flow during debugging.
- Edge cases tested:
  - High page index + filtered list + type switch state transition.
- Test files modified or added:
  - Modified `apps/web-next/e2e/tests/transactions.spec.ts`