### PR TITLE
bugfix(categories): reset pagination on type switch

### DIFF
--- a/apps/web-next/e2e/tests/categories.spec.ts
+++ b/apps/web-next/e2e/tests/categories.spec.ts
@@ -239,7 +239,7 @@ test.describe("Categories", () => {
     const ts = Date.now();
     const now = new Date().toISOString();
     const categoryPrefix = `e2e-category-pagination-${ts}-`;
-    const extraSpendCategories = Array.from({ length: 10 }).map((_, index) => ({
+    const extraSpendCategories = Array.from({ length: 11 }).map((_, index) => ({
       user_id: testUser.userId,
       type: "spend" as const,
       name: `${categoryPrefix}${index + 1}`,

--- a/apps/web-next/e2e/tests/categories.spec.ts
+++ b/apps/web-next/e2e/tests/categories.spec.ts
@@ -7,6 +7,7 @@ import {
   createCategoryForType,
   waitForFormReady,
   selectFromVisibleAntdDropdown,
+  supabaseAdmin,
 } from "../utils/test-helpers";
 
 test.describe("Categories", () => {
@@ -220,6 +221,76 @@ test.describe("Categories", () => {
     await expect(
       page.getByRole("cell", { name: spendCategoryName, exact: true })
     ).not.toBeVisible();
+  });
+
+  test("switching category type resets pagination and avoids 416", async ({
+    page,
+  }) => {
+    let hasRange416 = false;
+    page.on("response", (response) => {
+      if (
+        response.url().includes("/categories_with_usage") &&
+        response.status() === 416
+      ) {
+        hasRange416 = true;
+      }
+    });
+
+    const ts = Date.now();
+    const now = new Date().toISOString();
+    const categoryPrefix = `e2e-category-pagination-${ts}-`;
+    const extraSpendCategories = Array.from({ length: 10 }).map((_, index) => ({
+      user_id: testUser.userId,
+      type: "spend" as const,
+      name: `${categoryPrefix}${index + 1}`,
+      description: "pagination-regression",
+      created_at: now,
+      updated_at: now,
+    }));
+
+    try {
+      const { error: categoriesError } = await supabaseAdmin
+        .from("categories")
+        .insert(extraSpendCategories);
+      if (categoriesError) {
+        throw new Error(
+          `Failed to seed pagination categories: ${categoriesError.message}`
+        );
+      }
+
+      await page.goto("/categories");
+      await page.waitForLoadState("networkidle");
+
+      await page
+        .getByRole("radiogroup", { name: "segmented control" })
+        .getByText(/^spend$/i)
+        .click();
+      await page.waitForLoadState("networkidle");
+
+      const secondPageButton = page
+        .locator(".ant-pagination-item")
+        .filter({ hasText: /^2$/ })
+        .first();
+      await expect(secondPageButton).toBeVisible();
+      await secondPageButton.click();
+      await page.waitForLoadState("networkidle");
+      await expect(page).toHaveURL(/currentPage=2/);
+
+      await page
+        .getByRole("radiogroup", { name: "segmented control" })
+        .getByText(/^earn$/i)
+        .click();
+      await page.waitForLoadState("networkidle");
+
+      await expect(page).toHaveURL(/currentPage=1/);
+      expect(hasRange416).toBeFalsy();
+    } finally {
+      await supabaseAdmin
+        .from("categories")
+        .delete()
+        .eq("user_id", testUser.userId)
+        .like("name", `${categoryPrefix}%`);
+    }
   });
 
   [

--- a/apps/web-next/src/pages/categories/list.tsx
+++ b/apps/web-next/src/pages/categories/list.tsx
@@ -20,7 +20,7 @@ export const CategoryList = () => {
     TRANSACTION_TYPES.EARN
   );
 
-  const { tableProps } = useTable({
+  const { tableProps, setCurrentPage } = useTable({
     syncWithLocation: true,
     resource: "categories_with_usage",
     filters: {
@@ -46,7 +46,12 @@ export const CategoryList = () => {
           value: type,
         }))}
         value={categoryType}
-        onChange={(value) => setCategoryType(value as string)}
+        onChange={(value) => {
+          const nextType = value as string;
+          if (nextType === categoryType) return;
+          setCurrentPage(1);
+          setCategoryType(nextType);
+        }}
       />
       {tableProps.loading && !tableProps.dataSource?.length ? (
         <TableSkeleton columns={4} />


### PR DESCRIPTION
## Why

Switching category types while on page 2 could reuse the stale pagination cursor and trigger a 416 from Supabase.

## What Changed

- Reset category list pagination to page 1 when the segmented type changes.
- Added an e2e regression test covering the page-2 → type-switch flow and verifying no 416 occurs.

## Key Decisions

- Keep the fix localized to the category list instead of changing shared list behavior.
- Mirror the transaction list pattern for resetting pagination on filter changes.

## How This Affects the System

- User-facing changes: category type switches now load correctly from page 1.
- Breaking changes: none.

## Testing

- `npm run lint -- src/pages/categories/list.tsx e2e/tests/categories.spec.ts`
- `npm run check-types`
- `npm run test:e2e:ci -- e2e/tests/categories.spec.ts`