### PR TITLE
ci: speed up Playwright e2e runs

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,7 +12,7 @@ jobs:
   e2e-tests:
     environment: staging
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     if: github.event.deployment_status.state == 'success' || github.event_name == 'workflow_dispatch'
     steps:
     - uses: actions/checkout@v4

--- a/apps/web-next/playwright.config.ts
+++ b/apps/web-next/playwright.config.ts
@@ -25,8 +25,8 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  /* Keep CI modestly parallel while avoiding the local-DB contention of fully parallel test files. */
+  workers: process.env.CI ? 2 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [
     ["html", { outputFolder: "playwright-report" }],


### PR DESCRIPTION
## Why

The preview E2E workflow was hitting a hard 10-minute job timeout and running Playwright with a single worker in CI, which made runs slow and prone to cancellation.

## What Changed

- Updated `.github/workflows/playwright.yml` to increase the job timeout from 10 to 20 minutes.
- Updated `apps/web-next/playwright.config.ts` to use 2 workers in CI instead of 1.

## Key Decisions

- Keep `fullyParallel: false` to avoid making the suite more aggressive than necessary.
- Use a modest 2-worker CI setup first rather than splitting the workflow into multiple lanes, since that gives a low-risk speedup with minimal workflow complexity.

## How This Affects the System

- User-facing changes: none
- API changes: none
- Performance implications: faster E2E feedback in CI
- Database changes: none
- Breaking changes: none

## Testing

- Existing E2E workflow behavior reviewed against current CI setup.
- No code-path changes beyond CI configuration.