### PR TITLE
docs: mark category hierarchy docs done

### DIFF
--- a/docs/superpowers/plans/2026-06-27-category-hierarchy-display.md
+++ b/docs/superpowers/plans/2026-06-27-category-hierarchy-display.md
@@ -1,5 +1,7 @@
 # Category Hierarchy Display Implementation Plan
 
+> **Status: Done**
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Show transaction categories as `Parent / Child` (or just `Name` for roots) consistently in transactions list, create/edit category selectors, and transaction details.

--- a/docs/superpowers/plans/2026-07-04-issue-209-parent-aware-dropdown-sorting.md
+++ b/docs/superpowers/plans/2026-07-04-issue-209-parent-aware-dropdown-sorting.md
@@ -1,5 +1,7 @@
 # Issue #209 Parent-Aware Dropdown Sorting Implementation Plan
 
+> **Status: Done**
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Make category dropdowns sort alphabetically by full hierarchy label (`Parent / Child`) and ensure bank account dropdown ordering is explicitly alphabetical everywhere relevant.

--- a/docs/superpowers/specs/2026-06-27-category-hierarchy-display-design.md
+++ b/docs/superpowers/specs/2026-06-27-category-hierarchy-display-design.md
@@ -1,5 +1,7 @@
 # Category Hierarchy Display Design
 
+**Status:** Done
+
 ## Context
 
 Transaction UI currently shows only child category names in key places (transactions list, transaction create/edit category picker, transaction details). This becomes ambiguous when multiple leaves share the same child name under different parents (for example, `Food / Groceries` vs `Vacations / Groceries`).

--- a/docs/superpowers/specs/2026-07-04-issue-209-dropdown-sorting-design.md
+++ b/docs/superpowers/specs/2026-07-04-issue-209-dropdown-sorting-design.md
@@ -1,5 +1,7 @@
 # Issue #209: Parent-aware alphabetical dropdown sorting
 
+**Status:** Done
+
 ## Context
 
 Transaction category dropdowns currently fetch categories sorted by raw `name`, then display hierarchical labels as `Parent / Child`. This causes visually incorrect ordering (for example, `Utilities / Heating`, `Vacation`, `Utilities / Water`) because sorting ignores the parent segment. Transaction edit also does not explicitly sort bank accounts.


### PR DESCRIPTION
## Why

These design and implementation docs are complete, so they should be marked as done for easier tracking.

## What Changed

- Added a Done status marker to the category hierarchy display spec and plan.
- Added a Done status marker to the issue #209 dropdown sorting spec and plan.

## Key Decisions

- Kept the change limited to status markers only.
- Did not alter any doc content beyond completion state.

## How This Affects the System

- User-facing changes: none
- API changes: none
- Performance implications: none
- Database changes: none
- Breaking changes: none

## Testing

- Not run; documentation-only change.