### PR TITLE
docs: refresh README guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ## Tech Stack
 
 - **Backend:** [Supabase](https://supabase.com/) (PostgreSQL, Auth, Storage, Realtime)
-- **Frontend:** [Refine](https://refine.dev/) (coming soon)
+- **Frontend:** [apps/web-next](apps/web-next/) (Vite + React + Refine + Ant Design)
 
 ## Database
 
@@ -134,7 +134,7 @@ if (error) {
 ### Prerequisites
 
 - [Supabase CLI](https://supabase.com/docs/guides/cli)
-- [Node.js](https://nodejs.org/) (for frontend, coming soon)
+- [Node.js](https://nodejs.org/) (for the frontend app and tooling)
 - [Deno](https://deno.com/) (if using edge functions)
 
 ### Supabase CLI Commands

--- a/apps/web-next/README.MD
+++ b/apps/web-next/README.MD
@@ -39,7 +39,8 @@ Refine's hooks and components simplifies the development process and eliminates 
 
 - Playwright is configured to auto-start the dev server via `webServer` when `BASE_URL` is not set, so `npm run test:e2e` is usually all you need.
 - If you already have a server running, set `BASE_URL` to skip auto-start (e.g. `BASE_URL=http://localhost:5173 npm run test:e2e`).
-- In CI, start the server in a separate step and pass `BASE_URL` to reuse it; otherwise Playwright will launch `npm run dev` with a 120s timeout.
+- Use `npm run test:e2e:ci` for CI-friendly terminal output (`PLAYWRIGHT_HTML_OPEN=never` + list reporter).
+- In CI, Playwright uses 2 workers by default in `playwright.config.ts`, so the suite is no longer fully serial.
 
 ## Environment Visual Indicator
 

--- a/apps/web-next/e2e/README.md
+++ b/apps/web-next/e2e/README.md
@@ -13,7 +13,7 @@ This directory contains Playwright end-to-end tests for the web-next application
 
 2. Configure environment variables:
    - Copy `.env.local.example` to `.env.local` and fill in your Supabase credentials
-   - Or copy from the main web app: `cp ../web/.env.local .env.local`
+   - Or copy the frontend app's env file if you already have one: `cp ../.env.local .env.local`
 
 ### Environment Variables
 
@@ -22,7 +22,6 @@ Create a `.env.local` file with the following variables:
 ```bash
 # Supabase Configuration
 VITE_SUPABASE_URL=your_supabase_url_here
-NEXT_PUBLIC_SUPABASE_URL=your_supabase_url_here
 SUPABASE_SERVICE_ROLE_KEY=your_service_role_key_here
 
 # Playwright Configuration
@@ -41,6 +40,9 @@ npx playwright install
 ```bash
 # Run all tests
 npm run test:e2e
+
+# Run all tests with CI-friendly output
+npm run test:e2e:ci
 
 # Run tests in headed mode (see browser)
 npm run test:e2e:headed
@@ -112,7 +114,7 @@ When porting tests from `../web/e2e/tests/`, key differences to consider:
 
 ## Notes
 
-- Tests run sequentially to ensure data isolation
+- Playwright uses limited CI parallelism via the web app config (2 workers), while tests still rely on isolated users and cleanup.
 - Each test creates its own test user and cleans up after itself
 - Shared Supabase backend means test data setup is identical to web app
 - See the main project README for more information


### PR DESCRIPTION
## Why

The repo READMEs had a few stale references to the old frontend future-state and outdated E2E setup details.

## What Changed

- Updated the root README tech stack to point at `apps/web-next`.
- Updated the root README Node.js note to reflect current frontend/tooling usage.
- Updated the web-next README to mention `test:e2e:ci` and the current CI worker count.
- Updated the E2E README environment and test-running instructions to match the current Vite/Playwright setup.

## Key Decisions

- Kept the changes documentation-only.
- Reused current script and config names so the docs match what developers actually run.

## How This Affects the System

- User-facing changes: none
- API changes: none
- Performance implications: none
- Database changes: none
- Breaking changes: none

## Testing

- Not run; documentation-only change.