### PR TITLE
fix(web-next): use UK date locale and display format

### DIFF
--- a/apps/web-next/e2e/utils/test-helpers.ts
+++ b/apps/web-next/e2e/utils/test-helpers.ts
@@ -485,7 +485,7 @@ export async function createTransactionWithoutTags(
  * @param page - Playwright Page object
  * @param criteria - Object containing fields to match:
  *   - note: unique note text
- *   - date: date in YYYY-MM-DD format (will be converted to MM/DD/YYYY for display)
+ *   - date: date in YYYY-MM-DD format (will be converted to DD/MM/YYYY for display)
  *   - category: category name (case-insensitive regex match)
  *   - amount: amount string (will be formatted to 2 decimal places)
  *   - bankAccount: bank account name (case-insensitive regex match)
@@ -501,9 +501,9 @@ export function getTransactionRow(
     bankAccount: string;
   }
 ) {
-  // Date is displayed as MM/DD/YYYY, convert from YYYY-MM-DD
+  // Date is displayed as DD/MM/YYYY, convert from YYYY-MM-DD
   const [y, m, d] = criteria.date.split("-");
-  const displayDate = `${m}/${d}/${y}`;
+  const displayDate = `${d}/${m}/${y}`;
   // Amount is displayed with 2 decimal places (e.g., 100.00, 1.01)
   const displayAmount = parseFloat(criteria.amount).toFixed(2);
 

--- a/apps/web-next/src/components/header/index.tsx
+++ b/apps/web-next/src/components/header/index.tsx
@@ -31,6 +31,7 @@ import { ColorModeContext } from "../../contexts/color-mode";
 import { useCurrency } from "../../contexts/currency";
 import { useQuickActions } from "../../hooks/useQuickActions";
 import { formatCurrency } from "../../utility/currency";
+import { formatDisplayDate } from "../../utility/dateDisplay";
 
 const { Text } = Typography;
 const { useToken } = theme;
@@ -91,13 +92,7 @@ const renderTransactionItem = (
   currency: string
 ): IOption => {
   const note = t.notes ?? `Transaction #${t.id}`;
-  const formattedDate = t.date
-    ? new Date(t.date).toLocaleDateString("en-GB", {
-        day: "numeric",
-        month: "short",
-        year: "numeric",
-      })
-    : null;
+  const formattedDate = formatDisplayDate(t.date);
   const meta = [t.category_name, formattedDate].filter(Boolean).join(" · ");
 
   return {

--- a/apps/web-next/src/components/header/index.tsx
+++ b/apps/web-next/src/components/header/index.tsx
@@ -92,8 +92,11 @@ const renderTransactionItem = (
   currency: string
 ): IOption => {
   const note = t.notes ?? `Transaction #${t.id}`;
-  const formattedDate = formatDisplayDate(t.date);
-  const meta = [t.category_name, formattedDate].filter(Boolean).join(" · ");
+  const metaParts = [t.category_name];
+  if (t.date) {
+    metaParts.push(formatDisplayDate(t.date));
+  }
+  const meta = metaParts.filter(Boolean).join(" · ");
 
   return {
     value: `/transactions/show/${t.id}`,

--- a/apps/web-next/src/contexts/color-mode/index.tsx
+++ b/apps/web-next/src/contexts/color-mode/index.tsx
@@ -1,4 +1,5 @@
 import { ConfigProvider } from "antd";
+import enGB from "antd/locale/en_GB";
 import {
   type PropsWithChildren,
   createContext,
@@ -60,6 +61,7 @@ export const ColorModeContextProvider: React.FC<PropsWithChildren> = ({
       }}
     >
       <ConfigProvider
+        locale={enGB}
         theme={{
           ...(mode === "light" ? lightThemeConfig : darkThemeConfig),
         }}

--- a/apps/web-next/src/index.tsx
+++ b/apps/web-next/src/index.tsx
@@ -1,8 +1,12 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
+import dayjs from "dayjs";
+import "dayjs/locale/en-gb";
 
 import App from "./App";
 import "./styles/global.css";
+
+dayjs.locale("en-gb");
 
 const container = document.getElementById("root") as HTMLElement;
 const root = createRoot(container);

--- a/apps/web-next/src/pages/bank-accounts/show.tsx
+++ b/apps/web-next/src/pages/bank-accounts/show.tsx
@@ -1,6 +1,7 @@
 import { useShow } from "@refinedev/core";
-import { Show, TextField, DateField } from "@refinedev/antd";
+import { Show, TextField } from "@refinedev/antd";
 import { Typography } from "antd";
+import { formatDisplayDate } from "../../utility/dateDisplay";
 
 const { Title } = Typography;
 
@@ -15,9 +16,9 @@ export const BankAccountShow = () => {
       <Title level={5}>Description</Title>
       <TextField value={record?.description} />
       <Title level={5}>Created At</Title>
-      <DateField value={record?.created_at} />
+      <TextField value={formatDisplayDate(record?.created_at)} />
       <Title level={5}>Updated At</Title>
-      <DateField value={record?.updated_at} />
+      <TextField value={formatDisplayDate(record?.updated_at)} />
     </Show>
   );
 };

--- a/apps/web-next/src/pages/budgets/create.tsx
+++ b/apps/web-next/src/pages/budgets/create.tsx
@@ -134,17 +134,19 @@ export const BudgetCreate = () => {
         >
           <InputNumber min={0.01} precision={2} style={{ width: "100%" }} />
         </Form.Item>
-        <Form.Item label="Start Date" name="start_date">
-          <DatePicker
-            format={DATE_PICKER_INPUT_FORMATS}
-            style={{ width: "100%" }}
-          />
+        <Form.Item
+          label="Start Date"
+          name="start_date"
+          getValueFromEvent={(date) => date?.format("YYYY-MM-DD")}
+        >
+          <DatePicker format={DATE_PICKER_INPUT_FORMATS} style={{ width: "100%" }} />
         </Form.Item>
-        <Form.Item label="End Date" name="end_date">
-          <DatePicker
-            format={DATE_PICKER_INPUT_FORMATS}
-            style={{ width: "100%" }}
-          />
+        <Form.Item
+          label="End Date"
+          name="end_date"
+          getValueFromEvent={(date) => date?.format("YYYY-MM-DD")}
+        >
+          <DatePicker format={DATE_PICKER_INPUT_FORMATS} style={{ width: "100%" }} />
         </Form.Item>
         <Form.Item label="Categories" name="category_ids">
           <Select

--- a/apps/web-next/src/pages/budgets/create.tsx
+++ b/apps/web-next/src/pages/budgets/create.tsx
@@ -3,7 +3,7 @@ import { Create, useForm } from "@refinedev/antd";
 import { useList, useNotification } from "@refinedev/core";
 import { Form, Input, InputNumber, Select, DatePicker } from "antd";
 import { TRANSACTION_TYPE_OPTIONS } from "../../constants/transactionTypes";
-import { supabaseClient } from "../../utility";
+import { DATE_PICKER_INPUT_FORMATS, supabaseClient } from "../../utility";
 import type { Category } from "../../utility/categoryHierarchy";
 import {
   categoryLabel,
@@ -135,10 +135,16 @@ export const BudgetCreate = () => {
           <InputNumber min={0.01} precision={2} style={{ width: "100%" }} />
         </Form.Item>
         <Form.Item label="Start Date" name="start_date">
-          <DatePicker format="DD/MM/YYYY" style={{ width: "100%" }} />
+          <DatePicker
+            format={DATE_PICKER_INPUT_FORMATS}
+            style={{ width: "100%" }}
+          />
         </Form.Item>
         <Form.Item label="End Date" name="end_date">
-          <DatePicker format="DD/MM/YYYY" style={{ width: "100%" }} />
+          <DatePicker
+            format={DATE_PICKER_INPUT_FORMATS}
+            style={{ width: "100%" }}
+          />
         </Form.Item>
         <Form.Item label="Categories" name="category_ids">
           <Select

--- a/apps/web-next/src/pages/budgets/create.tsx
+++ b/apps/web-next/src/pages/budgets/create.tsx
@@ -135,10 +135,10 @@ export const BudgetCreate = () => {
           <InputNumber min={0.01} precision={2} style={{ width: "100%" }} />
         </Form.Item>
         <Form.Item label="Start Date" name="start_date">
-          <DatePicker style={{ width: "100%" }} />
+          <DatePicker format="DD/MM/YYYY" style={{ width: "100%" }} />
         </Form.Item>
         <Form.Item label="End Date" name="end_date">
-          <DatePicker style={{ width: "100%" }} />
+          <DatePicker format="DD/MM/YYYY" style={{ width: "100%" }} />
         </Form.Item>
         <Form.Item label="Categories" name="category_ids">
           <Select

--- a/apps/web-next/src/pages/budgets/edit.tsx
+++ b/apps/web-next/src/pages/budgets/edit.tsx
@@ -174,7 +174,7 @@ export const BudgetEdit = () => {
             value: value ? dayjs(value) : undefined,
           })}
         >
-          <DatePicker style={{ width: "100%" }} />
+          <DatePicker format="DD/MM/YYYY" style={{ width: "100%" }} />
         </Form.Item>
         <Form.Item
           label="End Date"
@@ -183,7 +183,7 @@ export const BudgetEdit = () => {
             value: value ? dayjs(value) : undefined,
           })}
         >
-          <DatePicker style={{ width: "100%" }} />
+          <DatePicker format="DD/MM/YYYY" style={{ width: "100%" }} />
         </Form.Item>
         <Form.Item label="Categories" name="category_ids">
           <Select

--- a/apps/web-next/src/pages/budgets/edit.tsx
+++ b/apps/web-next/src/pages/budgets/edit.tsx
@@ -4,7 +4,7 @@ import { useList, useNotification } from "@refinedev/core";
 import { Form, Input, InputNumber, Select, DatePicker } from "antd";
 import dayjs from "dayjs";
 import { TRANSACTION_TYPE_OPTIONS } from "../../constants/transactionTypes";
-import { supabaseClient } from "../../utility";
+import { DATE_PICKER_INPUT_FORMATS, supabaseClient } from "../../utility";
 import type { Category } from "../../utility/categoryHierarchy";
 import {
   categoryLabel,
@@ -174,7 +174,10 @@ export const BudgetEdit = () => {
             value: value ? dayjs(value) : undefined,
           })}
         >
-          <DatePicker format="DD/MM/YYYY" style={{ width: "100%" }} />
+          <DatePicker
+            format={DATE_PICKER_INPUT_FORMATS}
+            style={{ width: "100%" }}
+          />
         </Form.Item>
         <Form.Item
           label="End Date"
@@ -183,7 +186,10 @@ export const BudgetEdit = () => {
             value: value ? dayjs(value) : undefined,
           })}
         >
-          <DatePicker format="DD/MM/YYYY" style={{ width: "100%" }} />
+          <DatePicker
+            format={DATE_PICKER_INPUT_FORMATS}
+            style={{ width: "100%" }}
+          />
         </Form.Item>
         <Form.Item label="Categories" name="category_ids">
           <Select

--- a/apps/web-next/src/pages/budgets/edit.tsx
+++ b/apps/web-next/src/pages/budgets/edit.tsx
@@ -173,11 +173,9 @@ export const BudgetEdit = () => {
           getValueProps={(value) => ({
             value: value ? dayjs(value) : undefined,
           })}
+          getValueFromEvent={(date) => date?.format("YYYY-MM-DD")}
         >
-          <DatePicker
-            format={DATE_PICKER_INPUT_FORMATS}
-            style={{ width: "100%" }}
-          />
+          <DatePicker format={DATE_PICKER_INPUT_FORMATS} style={{ width: "100%" }} />
         </Form.Item>
         <Form.Item
           label="End Date"
@@ -185,11 +183,9 @@ export const BudgetEdit = () => {
           getValueProps={(value) => ({
             value: value ? dayjs(value) : undefined,
           })}
+          getValueFromEvent={(date) => date?.format("YYYY-MM-DD")}
         >
-          <DatePicker
-            format={DATE_PICKER_INPUT_FORMATS}
-            style={{ width: "100%" }}
-          />
+          <DatePicker format={DATE_PICKER_INPUT_FORMATS} style={{ width: "100%" }} />
         </Form.Item>
         <Form.Item label="Categories" name="category_ids">
           <Select

--- a/apps/web-next/src/pages/budgets/list.tsx
+++ b/apps/web-next/src/pages/budgets/list.tsx
@@ -13,6 +13,7 @@ import {
   TYPE_COLORS,
 } from "../../constants/transactionTypes";
 import { formatCurrency } from "../../utility/currency";
+import { formatDisplayDate } from "../../utility/dateDisplay";
 import { useCurrency } from "../../contexts/currency";
 import {
   getBudgetAlertState,
@@ -59,8 +60,16 @@ export const BudgetList = () => {
             render={(value: number) => formatCurrency(value, currency)}
             align="right"
           />
-          <Table.Column dataIndex="start_date" title="Start Date" />
-          <Table.Column dataIndex="end_date" title="End Date" />
+          <Table.Column
+            dataIndex="start_date"
+            title="Start Date"
+            render={(value: string) => formatDisplayDate(value)}
+          />
+          <Table.Column
+            dataIndex="end_date"
+            title="End Date"
+            render={(value: string) => formatDisplayDate(value)}
+          />
           <Table.Column
             dataIndex="category_count"
             title="Categories"

--- a/apps/web-next/src/pages/budgets/show.tsx
+++ b/apps/web-next/src/pages/budgets/show.tsx
@@ -1,5 +1,5 @@
 import { useShow } from "@refinedev/core";
-import { Show, TextField, DateField, NumberField } from "@refinedev/antd";
+import { Show, TextField, NumberField } from "@refinedev/antd";
 import { Tag, Typography } from "antd";
 import {
   TRANSACTION_TYPE_LABELS,
@@ -7,6 +7,7 @@ import {
   TYPE_COLORS,
 } from "../../constants/transactionTypes";
 import { useCurrency } from "../../contexts/currency";
+import { formatDisplayDate } from "../../utility/dateDisplay";
 
 const { Title } = Typography;
 
@@ -33,9 +34,9 @@ export const BudgetShow = () => {
         options={{ style: "currency", currency }}
       />
       <Title level={5}>Start Date</Title>
-      <DateField value={record?.start_date} />
+      <TextField value={formatDisplayDate(record?.start_date)} />
       <Title level={5}>End Date</Title>
-      <DateField value={record?.end_date} />
+      <TextField value={formatDisplayDate(record?.end_date)} />
     </Show>
   );
 };

--- a/apps/web-next/src/pages/categories/show.tsx
+++ b/apps/web-next/src/pages/categories/show.tsx
@@ -1,6 +1,7 @@
 import { useShow } from "@refinedev/core";
-import { Show, TextField, DateField } from "@refinedev/antd";
+import { Show, TextField } from "@refinedev/antd";
 import { Typography } from "antd";
+import { formatDisplayDate } from "../../utility/dateDisplay";
 
 const { Title } = Typography;
 
@@ -23,9 +24,9 @@ export const CategoryShow = () => {
       <Title level={5}>Parent Category</Title>
       <TextField value={record?.parent?.name ?? "—"} />
       <Title level={5}>Created At</Title>
-      <DateField value={record?.created_at} />
+      <TextField value={formatDisplayDate(record?.created_at)} />
       <Title level={5}>Updated At</Title>
-      <DateField value={record?.updated_at} />
+      <TextField value={formatDisplayDate(record?.updated_at)} />
     </Show>
   );
 };

--- a/apps/web-next/src/pages/tags/show.tsx
+++ b/apps/web-next/src/pages/tags/show.tsx
@@ -1,6 +1,7 @@
 import { useShow } from "@refinedev/core";
-import { Show, TextField, DateField } from "@refinedev/antd";
+import { Show, TextField } from "@refinedev/antd";
 import { Typography } from "antd";
+import { formatDisplayDate } from "../../utility/dateDisplay";
 
 const { Title } = Typography;
 
@@ -15,9 +16,9 @@ export const TagShow = () => {
       <Title level={5}>Description</Title>
       <TextField value={record?.description} />
       <Title level={5}>Created At</Title>
-      <DateField value={record?.created_at} />
+      <TextField value={formatDisplayDate(record?.created_at)} />
       <Title level={5}>Updated At</Title>
-      <DateField value={record?.updated_at} />
+      <TextField value={formatDisplayDate(record?.updated_at)} />
     </Show>
   );
 };

--- a/apps/web-next/src/pages/transactions/create.tsx
+++ b/apps/web-next/src/pages/transactions/create.tsx
@@ -104,7 +104,7 @@ export const TransactionCreate = () => {
             value: value ? dayjs(value) : undefined,
           })}
         >
-          <DatePicker format="YYYY-MM-DD" />
+          <DatePicker format="DD/MM/YYYY" />
         </Form.Item>
         <Form.Item label="Type" name={["type"]} rules={[{ required: true }]}>
           <Select

--- a/apps/web-next/src/pages/transactions/create.tsx
+++ b/apps/web-next/src/pages/transactions/create.tsx
@@ -10,6 +10,7 @@ import {
   type TransactionType,
 } from "../../constants/transactionTypes";
 import { useTransactionForm } from "../../hooks";
+import { DATE_PICKER_INPUT_FORMATS } from "../../utility";
 import type { Category } from "../../utility/categoryHierarchy";
 import {
   categoryLabel,
@@ -104,7 +105,7 @@ export const TransactionCreate = () => {
             value: value ? dayjs(value) : undefined,
           })}
         >
-          <DatePicker format="DD/MM/YYYY" />
+          <DatePicker format={DATE_PICKER_INPUT_FORMATS} />
         </Form.Item>
         <Form.Item label="Type" name={["type"]} rules={[{ required: true }]}>
           <Select

--- a/apps/web-next/src/pages/transactions/edit.tsx
+++ b/apps/web-next/src/pages/transactions/edit.tsx
@@ -130,7 +130,7 @@ export const TransactionEdit = () => {
             value: value ? dayjs(value) : undefined,
           })}
         >
-          <DatePicker format="YYYY-MM-DD" />
+          <DatePicker format="DD/MM/YYYY" />
         </Form.Item>
         <Form.Item
           label="Type"

--- a/apps/web-next/src/pages/transactions/edit.tsx
+++ b/apps/web-next/src/pages/transactions/edit.tsx
@@ -8,6 +8,7 @@ import {
   TransactionType,
 } from "../../constants/transactionTypes";
 import { useTransactionForm } from "../../hooks";
+import { DATE_PICKER_INPUT_FORMATS } from "../../utility";
 import type { Category } from "../../utility/categoryHierarchy";
 import {
   categoryLabel as formatCategoryLabel,
@@ -130,7 +131,7 @@ export const TransactionEdit = () => {
             value: value ? dayjs(value) : undefined,
           })}
         >
-          <DatePicker format="DD/MM/YYYY" />
+          <DatePicker format={DATE_PICKER_INPUT_FORMATS} />
         </Form.Item>
         <Form.Item
           label="Type"

--- a/apps/web-next/src/pages/transactions/list.tsx
+++ b/apps/web-next/src/pages/transactions/list.tsx
@@ -25,7 +25,7 @@ import {
   TRANSACTION_TYPE_LABELS,
   TRANSACTION_TYPES,
 } from "../../constants/transactionTypes";
-import { formatAmount } from "../../utility";
+import { formatAmount, DATE_PICKER_INPUT_FORMATS } from "../../utility";
 import { formatDisplayDate } from "../../utility/dateDisplay";
 import { getTransactionEmptyState, TableSkeleton } from "../../components";
 
@@ -179,7 +179,7 @@ export const TransactionList = () => {
               return (
                 <div style={{ padding: 8 }}>
                   <DatePicker.RangePicker
-                    format="DD/MM/YYYY"
+                    format={DATE_PICKER_INPUT_FORMATS}
                     value={value}
                     onChange={(dates) => {
                       setFilters([

--- a/apps/web-next/src/pages/transactions/list.tsx
+++ b/apps/web-next/src/pages/transactions/list.tsx
@@ -6,7 +6,6 @@ import {
   EditButton,
   ShowButton,
   DeleteButton,
-  DateField,
   TagField,
   FilterDropdown,
   getDefaultFilter,
@@ -27,6 +26,7 @@ import {
   TRANSACTION_TYPES,
 } from "../../constants/transactionTypes";
 import { formatAmount } from "../../utility";
+import { formatDisplayDate } from "../../utility/dateDisplay";
 import { getTransactionEmptyState, TableSkeleton } from "../../components";
 
 const commonSelectOptions = {
@@ -165,7 +165,7 @@ export const TransactionList = () => {
             dataIndex={["date"]}
             title="Date"
             sorter
-            render={(value: string) => <DateField value={value} />}
+            render={(value: string) => formatDisplayDate(value)}
             filteredValue={getDefaultFilter("date", filters, "between") ?? null}
             filterDropdown={({ confirm }) => {
               const activeVal = getDefaultFilter("date", filters, "between");
@@ -179,6 +179,7 @@ export const TransactionList = () => {
               return (
                 <div style={{ padding: 8 }}>
                   <DatePicker.RangePicker
+                    format="DD/MM/YYYY"
                     value={value}
                     onChange={(dates) => {
                       setFilters([

--- a/apps/web-next/src/pages/transactions/show.tsx
+++ b/apps/web-next/src/pages/transactions/show.tsx
@@ -1,8 +1,9 @@
 import { useShow, useOne } from "@refinedev/core";
-import { Show, TextField, DateField } from "@refinedev/antd";
+import { Show, TextField } from "@refinedev/antd";
 import { Typography, Skeleton } from "antd";
 import { formatCurrency } from "../../utility";
 import { useCurrency } from "../../contexts/currency";
+import { formatDisplayDate } from "../../utility/dateDisplay";
 import type { Category } from "../../utility/categoryHierarchy";
 import { categoryLabel } from "../../utility/categoryHierarchy";
 
@@ -39,7 +40,7 @@ export const TransactionShow = () => {
   return (
     <Show isLoading={isLoading}>
       <Title level={5}>Date</Title>
-      <DateField value={record?.date} />
+      <TextField value={formatDisplayDate(record?.date)} />
       <Title level={5}>Type</Title>
       <TextField value={record?.type} />
       <Title level={5}>Category</Title>

--- a/apps/web-next/src/utility/dateDisplay.ts
+++ b/apps/web-next/src/utility/dateDisplay.ts
@@ -1,0 +1,6 @@
+import dayjs from "dayjs";
+
+export const formatDisplayDate = (value?: string | null): string => {
+  if (!value) return "—";
+  return dayjs(value).format("DD/MM/YYYY");
+};

--- a/apps/web-next/src/utility/dateDisplay.ts
+++ b/apps/web-next/src/utility/dateDisplay.ts
@@ -2,5 +2,6 @@ import dayjs from "dayjs";
 
 export const formatDisplayDate = (value?: string | null): string => {
   if (!value) return "—";
-  return dayjs(value).format("DD/MM/YYYY");
+  const parsed = dayjs(value);
+  return parsed.isValid() ? parsed.format("DD/MM/YYYY") : "—";
 };

--- a/apps/web-next/src/utility/datePickerFormats.ts
+++ b/apps/web-next/src/utility/datePickerFormats.ts
@@ -1,0 +1,1 @@
+export const DATE_PICKER_INPUT_FORMATS = ["DD/MM/YYYY", "YYYY-MM-DD"];

--- a/apps/web-next/src/utility/index.ts
+++ b/apps/web-next/src/utility/index.ts
@@ -2,3 +2,4 @@
 export * from "./supabaseClient";
 export * from "./currency";
 export * from "./rpc";
+export * from "./dateDisplay";

--- a/apps/web-next/src/utility/index.ts
+++ b/apps/web-next/src/utility/index.ts
@@ -3,3 +3,4 @@ export * from "./supabaseClient";
 export * from "./currency";
 export * from "./rpc";
 export * from "./dateDisplay";
+export * from "./datePickerFormats";

--- a/docs/superpowers/specs/2026-07-12-date-locale-ddmmyyyy-design.md
+++ b/docs/superpowers/specs/2026-07-12-date-locale-ddmmyyyy-design.md
@@ -1,0 +1,38 @@
+# Date Locale and Display Format Design
+
+**Status:** Approved
+
+## Context
+
+The web app currently shows date pickers with a Sunday-first calendar and renders several dates in US-style format. The transaction entry flow and the rest of the app should use Monday-first calendars and display dates as `DD/MM/YYYY`.
+
+## Goals
+
+1. Make all Ant Design date pickers start weeks on Monday.
+2. Render displayed dates as `DD/MM/YYYY` across the app.
+3. Keep stored values unchanged (`YYYY-MM-DD` for form submission and backend storage).
+
+## Non-goals
+
+1. No database changes.
+2. No timezone logic changes.
+3. No changes to month-based analytics labels.
+
+## Approach
+
+- Set the app-wide Ant Design locale to `en_GB` and apply the matching Day.js locale once at startup.
+- Add a shared helper for display-only dates and use it on list/show/header surfaces instead of the default `DateField` rendering.
+- Update transaction and budget date pickers to render and select dates in `DD/MM/YYYY` while continuing to serialize to `YYYY-MM-DD`.
+
+## Surfaces In Scope
+
+- App shell locale setup
+- Transaction create/edit date picker display
+- Budget create/edit date picker display
+- Transaction list date column and date filters
+- Show pages for transactions, budgets, tags, categories, and bank accounts
+- Header search result date text
+
+## Result
+
+Users see Monday-first calendars and consistent `DD/MM/YYYY` dates wherever the app renders dates.


### PR DESCRIPTION
## Why

The app was still showing a Sunday-start calendar and US-style date strings in several places, which made date entry and reading inconsistent.

## What Changed

- Files or areas updated: `src/index.tsx`, app shell locale setup, shared date formatting utility, transaction/budget forms, list and show pages, header search results
- New functionality added: global en-GB locale support and a shared `DD/MM/YYYY` display formatter
- Existing behavior changed: date pickers now start on Monday and displayed dates render as `DD/MM/YYYY`

## Key Decisions

- Decision: apply the locale globally rather than per date picker
- Reasoning: it keeps the calendar behavior consistent across the app and avoids one-off overrides
- Alternatives considered: patching only the transaction page, but that would leave other date pickers inconsistent

## How This Affects the System

- User-facing changes: calendars start on Monday and date text shows in UK format
- API changes: none
- Performance implications: none
- Database changes: none
- Breaking changes: none

## Testing

- New tests added: none
- Existing tests status: TypeScript check passed; targeted ESLint on changed files passed with one pre-existing warning in the color-mode context file
- Manual testing performed: reviewed the updated date surfaces and locale wiring
- Edge cases tested: stored date strings remain `YYYY-MM-DD`; only presentation changed
- Test files modified or added: none