### PR TITLE
feat(categories): prefill type from selected tab

### DIFF
--- a/apps/web-next/e2e/tests/categories.spec.ts
+++ b/apps/web-next/e2e/tests/categories.spec.ts
@@ -41,6 +41,57 @@ test.describe("Categories", () => {
     });
   });
 
+  test("create from selected category tab preselects type", async ({
+    page,
+  }) => {
+    const type = "earn";
+    const ts = Date.now();
+    const parentName = `e2e-category-prefill-parent-${ts}`;
+
+    await createCategoryForType(page, type, parentName);
+
+    await page.goto("/categories");
+    await page
+      .getByRole("radiogroup", { name: "segmented control" })
+      .getByText(new RegExp(type, "i"))
+      .click();
+
+    await page.getByRole("button", { name: "Create" }).click();
+
+    await expect(page).toHaveURL(
+      new RegExp(`/categories/create\\?source=categories-list&type=${type}$`)
+    );
+    await expect(
+      page.locator(".ant-select-selection-item").filter({ hasText: /^earn$/i })
+    ).toBeVisible();
+
+    await page
+      .getByRole("combobox", { name: /parent category/i })
+      .click({ force: true });
+    await expect(
+      page.locator(".ant-select-dropdown:visible").getByTitle(
+        new RegExp(`^${parentName}$`, "i")
+      )
+    ).toBeVisible();
+  });
+
+  test("direct create stays blank", async ({ page }) => {
+    await page.goto("/categories/create");
+
+    await expect(page).toHaveURL("/categories/create");
+    await expect(
+      page.locator(".ant-select-selection-item").filter({ hasText: /^(earn|spend|save)$/i })
+    ).toHaveCount(0);
+  });
+
+  test("invalid query params stay blank", async ({ page }) => {
+    await page.goto("/categories/create?source=categories-list&type=invalid");
+
+    await expect(
+      page.locator(".ant-select-selection-item").filter({ hasText: /^(earn|spend|save)$/i })
+    ).toHaveCount(0);
+  });
+
   test("user can edit a category", async ({ page }) => {
     const ts = Date.now();
     const categoryType = "earn";

--- a/apps/web-next/e2e/tests/data-reset.spec.ts
+++ b/apps/web-next/e2e/tests/data-reset.spec.ts
@@ -4,6 +4,7 @@ import {
   deleteTestUser,
   loginUser,
   cleanupReferenceDataForUser,
+  createCategoryForType,
   seedReferenceDataForUser,
   createBudget,
   createTransactionWithoutTags,
@@ -134,12 +135,7 @@ test.describe("Data Reset", () => {
 
   test("data reset removes all categories", async ({ page }) => {
     // Create a category
-    await page.goto("/categories");
-    await page.getByRole("button", { name: /create/i }).click();
-    await page.getByRole("combobox", { name: "* Type" }).click();
-    await page.getByTitle(/spend/i).click();
-    await page.getByRole("textbox", { name: "* Name" }).fill("Test Category");
-    await page.getByRole("button", { name: /save/i }).click();
+    await createCategoryForType(page, "spend", "Test Category");
 
     // Verify redirected to categories list
     await expect(page).toHaveURL(/\/categories/);

--- a/apps/web-next/e2e/utils/test-helpers.ts
+++ b/apps/web-next/e2e/utils/test-helpers.ts
@@ -374,7 +374,7 @@ export async function createCategoryForType(
   await typeOption.waitFor({ state: "visible" });
   await typeOption.click();
   await expect(
-    page.locator("#root").getByTitle(new RegExp(type, "i"))
+    page.locator("#root").getByTitle(new RegExp(escapedType, "i"))
   ).toBeVisible();
 
   // Fill in name and description

--- a/apps/web-next/e2e/utils/test-helpers.ts
+++ b/apps/web-next/e2e/utils/test-helpers.ts
@@ -360,16 +360,19 @@ export async function createCategoryForType(
   description?: string
 ) {
   await page.goto("/categories");
-
   // Open create category modal
   await page.getByRole("button", { name: /create/i }).click();
-  await expect(
-    page.getByRole("heading", { name: "Create Category" })
-  ).toBeVisible();
+  await expect(page).toHaveURL(/\/categories\/create/);
+  await expect(page.getByRole("combobox", { name: /type/i })).toBeVisible();
 
   // Select category type
-  await page.getByRole("combobox", { name: "* Type" }).click();
-  await page.getByTitle(new RegExp(type, "i")).click();
+  const escapedType = type.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  await page.getByRole("combobox", { name: "* Type" }).click({ force: true });
+  const typeOption = page
+    .locator(".ant-select-dropdown:visible")
+    .getByTitle(new RegExp(`^${escapedType}$`, "i"));
+  await typeOption.waitFor({ state: "visible" });
+  await typeOption.click();
   await expect(
     page.locator("#root").getByTitle(new RegExp(type, "i"))
   ).toBeVisible();

--- a/apps/web-next/e2e/utils/test-helpers.ts
+++ b/apps/web-next/e2e/utils/test-helpers.ts
@@ -360,7 +360,7 @@ export async function createCategoryForType(
   description?: string
 ) {
   await page.goto("/categories");
-  // Open create category modal
+  // Open create category page
   await page.getByRole("button", { name: /create/i }).click();
   await expect(page).toHaveURL(/\/categories\/create/);
   await expect(page.getByRole("combobox", { name: /type/i })).toBeVisible();

--- a/apps/web-next/src/pages/categories/create.tsx
+++ b/apps/web-next/src/pages/categories/create.tsx
@@ -1,24 +1,57 @@
 import { Create, useForm, useSelect } from "@refinedev/antd";
 import { Form, Input, Select } from "antd";
-import { useState } from "react";
-import { TRANSACTION_TYPE_OPTIONS } from "../../constants/transactionTypes";
+import { useMemo } from "react";
+import { useSearchParams } from "react-router";
+import {
+  TRANSACTION_TYPES,
+  TRANSACTION_TYPE_OPTIONS,
+} from "../../constants/transactionTypes";
 
 export const CategoryCreate = () => {
+  const [searchParams] = useSearchParams();
   const { formProps, saveButtonProps } = useForm();
-  const [selectedType, setSelectedType] = useState<string | undefined>();
+  const initialType = useMemo<string | undefined>(() => {
+    const validTypes = new Set<string>(Object.values(TRANSACTION_TYPES));
+    const source = searchParams.get("source");
+    const rawType = searchParams.get("type");
+
+    if (source !== "categories-list") return undefined;
+    if (!rawType || !validTypes.has(rawType)) {
+      return undefined;
+    }
+
+    return rawType;
+  }, [searchParams]);
+
+  const mergedInitialValues = useMemo(() => {
+    const existingInitialValues = formProps.initialValues ?? {};
+
+    if (!initialType) {
+      return Object.keys(existingInitialValues).length
+        ? existingInitialValues
+        : undefined;
+    }
+
+    return {
+      ...existingInitialValues,
+      type: initialType,
+    };
+  }, [formProps.initialValues, initialType]);
+
+  const currentType = Form.useWatch("type", formProps.form) ?? initialType;
 
   const { selectProps: parentSelectProps } = useSelect({
     resource: "categories_with_usage",
     optionLabel: "name",
     optionValue: "id",
     sorters: [{ field: "name", order: "asc" }],
-    filters: selectedType
+    filters: currentType
       ? [
-          { field: "type", operator: "eq", value: selectedType },
+          { field: "type", operator: "eq", value: currentType },
           { field: "parent_id", operator: "null", value: null },
         ]
       : [],
-    queryOptions: { enabled: !!selectedType },
+    queryOptions: { enabled: !!currentType },
     pagination: { pageSize: 200 },
   });
 
@@ -26,10 +59,10 @@ export const CategoryCreate = () => {
     <Create saveButtonProps={saveButtonProps}>
       <Form
         {...formProps}
+        initialValues={mergedInitialValues}
         layout="vertical"
         onValuesChange={(changed) => {
           if (changed.type !== undefined) {
-            setSelectedType(changed.type);
             formProps.form?.setFieldValue("parent_id", undefined);
           }
         }}
@@ -48,7 +81,7 @@ export const CategoryCreate = () => {
             {...parentSelectProps}
             allowClear
             placeholder="No parent (top-level category)"
-            disabled={!selectedType}
+            disabled={!currentType}
           />
         </Form.Item>
       </Form>

--- a/apps/web-next/src/pages/categories/list.tsx
+++ b/apps/web-next/src/pages/categories/list.tsx
@@ -6,8 +6,9 @@ import {
   ShowButton,
   DeleteButton,
 } from "@refinedev/antd";
-import { Table, Space, Segmented } from "antd";
+import { Table, Space, Segmented, Button } from "antd";
 import { useState } from "react";
+import { useNavigate } from "react-router";
 import {
   TRANSACTION_TYPES,
   TRANSACTION_TYPE_LABELS,
@@ -16,6 +17,7 @@ import { getCategoryEmptyState, TableSkeleton } from "../../components";
 
 export const CategoryList = () => {
   const invalidate = useInvalidate();
+  const navigate = useNavigate();
   const [categoryType, setCategoryType] = useState<string>(
     TRANSACTION_TYPES.EARN
   );
@@ -41,7 +43,22 @@ export const CategoryList = () => {
   const categoryEmptyState = getCategoryEmptyState();
 
   return (
-    <List>
+    <List
+      headerButtons={() => (
+        <Button
+          type="primary"
+          onClick={() => {
+            const params = new URLSearchParams({
+              source: "categories-list",
+              type: categoryType,
+            });
+            navigate(`/categories/create?${params.toString()}`);
+          }}
+        >
+          Create
+        </Button>
+      )}
+    >
       <Segmented
         aria-label="segmented control"
         options={Object.values(TRANSACTION_TYPES).map((type) => ({

--- a/docs/superpowers/plans/2026-07-12-category-create-type-prefill.md
+++ b/docs/superpowers/plans/2026-07-12-category-create-type-prefill.md
@@ -1,0 +1,151 @@
+# Category Create Type Prefill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prefill category Type on `/categories/create` only when the user arrives from the Categories list with a tab-selected type.
+
+**Architecture:** Use an explicit query-string handoff from the Categories list to the create page. The create page validates that context, seeds the form initial value, and derives the parent-category dropdown filter from the current form value so the dropdown works immediately on load.
+
+**Tech Stack:** TypeScript, React 19, Refine, Ant Design 5, react-router, Playwright
+
+---
+
+### Task 1: Add explicit category create navigation
+
+**Files:**
+- Modify: `apps/web-next/src/pages/categories/list.tsx`
+
+- [ ] **Step 1: Update the list page create action to include the current tab type**
+
+Replace the default `<List>` header create behavior with a button that navigates to `/categories/create?source=categories-list&type=<activeType>`.
+
+```tsx
+<List
+  headerButtons={() => (
+    <Button
+      type="primary"
+      onClick={() => {
+        const params = new URLSearchParams({
+          source: "categories-list",
+          type: categoryType,
+        });
+        navigate(`/categories/create?${params.toString()}`);
+      }}
+    >
+      Create
+    </Button>
+  )}
+>
+```
+
+- [ ] **Step 2: Verify the list page still compiles cleanly**
+
+Run: `cd apps/web-next && npm run check-types`
+Expected: pass with no TypeScript errors in `pages/categories/list.tsx`.
+
+### Task 2: Prefill category type and seed dependent dropdown state
+
+**Files:**
+- Modify: `apps/web-next/src/pages/categories/create.tsx`
+
+- [ ] **Step 1: Add query-param parsing and type validation**
+
+Read `source` and `type` from `useSearchParams`, validate against the existing transaction/category type constants, and compute a merged initial value only when the source is `categories-list`.
+
+```tsx
+const [searchParams] = useSearchParams();
+const initialType = useMemo<string | undefined>(() => {
+  const source = searchParams.get("source");
+  const rawType = searchParams.get("type");
+
+  if (source !== "categories-list") return undefined;
+  if (!rawType || !VALID_TRANSACTION_TYPES.has(rawType)) return undefined;
+
+  return rawType;
+}, [searchParams]);
+```
+
+- [ ] **Step 2: Switch the parent-category filter from local mirrored state to form-driven state**
+
+Use `Form.useWatch("type", formProps.form)` so the selected type is available on first render when the form has an initial value.
+
+```tsx
+const currentType = Form.useWatch("type", formProps.form) ?? initialType;
+```
+
+Then drive the `useSelect` filters and `queryOptions.enabled` from `currentType` instead of a separate `useState` mirror.
+
+- [ ] **Step 3: Preserve the existing parent reset behavior on type change**
+
+Keep the form `onValuesChange` handler so changing Type clears `parent_id`.
+
+```tsx
+onValuesChange={(changed) => {
+  if (changed.type !== undefined) {
+    formProps.form?.setFieldValue("parent_id", undefined);
+  }
+}}
+```
+
+- [ ] **Step 4: Verify the create page still compiles cleanly**
+
+Run: `cd apps/web-next && npm run check-types`
+Expected: pass with no TypeScript errors in `pages/categories/create.tsx`.
+
+### Task 3: Add e2e coverage for the prefill flow
+
+**Files:**
+- Modify: `apps/web-next/e2e/tests/categories.spec.ts`
+
+- [ ] **Step 1: Add a create-from-tab test**
+
+Create a test that visits `/categories`, selects each category tab, clicks Create, and verifies the create form opens with the matching Type selected.
+
+```ts
+test("create from selected category tab preselects type", async ({ page }) => {
+  await page.goto("/categories");
+  await page.getByRole("radiogroup", { name: "segmented control" }).getByText(/earn/i).click();
+  await page.getByRole("button", { name: "Create" }).click();
+  await expect(page).toHaveURL(/\/categories\/create\?source=categories-list&type=earn/);
+  await expect(
+    page.locator(".ant-select-selection-item").filter({ hasText: /^earn$/i })
+  ).toBeVisible();
+});
+```
+
+- [ ] **Step 2: Add a direct-create blank-state test**
+
+Navigate directly to `/categories/create` and verify the Type field starts empty.
+
+- [ ] **Step 3: Add an invalid-query-param test**
+
+Navigate to `/categories/create?source=categories-list&type=invalid` and verify the Type field stays empty.
+
+- [ ] **Step 4: Run the targeted categories e2e file**
+
+Run: `cd apps/web-next && npm run test:e2e:ci -- e2e/tests/categories.spec.ts`
+Expected: the category suite passes, including the new prefill coverage.
+
+### Task 4: Final verification
+
+**Files:**
+- Modified: `apps/web-next/src/pages/categories/list.tsx`
+- Modified: `apps/web-next/src/pages/categories/create.tsx`
+- Modified: `apps/web-next/e2e/tests/categories.spec.ts`
+
+- [ ] **Step 1: Run type checks once more**
+
+Run: `cd apps/web-next && npm run check-types`
+Expected: pass.
+
+- [ ] **Step 2: Run the focused e2e suite once more**
+
+Run: `cd apps/web-next && npm run test:e2e:ci -- e2e/tests/categories.spec.ts`
+Expected: pass.
+
+- [ ] **Step 3: Commit the implementation**
+
+```bash
+git add apps/web-next/src/pages/categories/list.tsx apps/web-next/src/pages/categories/create.tsx apps/web-next/e2e/tests/categories.spec.ts
+git commit -m "feat(categories): prefill type from selected tab"
+```

--- a/docs/superpowers/specs/2026-07-12-category-create-type-prefill-design.md
+++ b/docs/superpowers/specs/2026-07-12-category-create-type-prefill-design.md
@@ -1,0 +1,89 @@
+# Category Create Type Prefill Design
+
+## Goal
+
+Reduce friction when creating categories by preselecting the Type field when the user opens the create page from the Categories list with a tab selected. Keep Type unselected for direct `/categories/create` visits and other navigation paths.
+
+## Scope
+
+In scope:
+- Categories list create navigation
+- Category create page initial type selection logic
+- Initial parent-category dropdown wiring so it works on first render
+- Validation guardrails for query params
+- Targeted tests for prefill behavior
+
+Out of scope:
+- Changing the default tab on the Categories list
+- Persisting a global "last used type"
+- Inferring type from route history or other pages
+
+## Approach
+
+Use an explicit URL handoff, matching the transaction prefill flow:
+
+1. On the Categories list page, override the Create button so it links to:
+   - `/categories/create?source=categories-list&type=<activeType>`
+2. On the Category create page, read query params and prefill Type only when:
+   - `source === "categories-list"`
+   - `type` is a valid category type (`earn | spend | save`)
+3. For direct opens or invalid/missing params, keep Type unselected.
+
+This keeps behavior explicit, predictable, and consistent with the existing transactions implementation.
+
+## Component-Level Design
+
+### CategoryList (`pages/categories/list.tsx`)
+
+- Keep the existing segmented filter behavior as-is.
+- Add a custom Create button so the current tab type is included in query params.
+- Do not change filters, pagination resets, or table behavior.
+
+### CategoryCreate (`pages/categories/create.tsx`)
+
+- Read `source` and `type` from `useSearchParams` (react-router).
+- Compute a validated initial type only when the source matches the Categories list and the type is one of the supported values.
+- Pass the validated type into form initial values so Type is preselected on first render.
+- Drive the parent-category dropdown from the form's current Type value, not from an independent local mirror, so the dropdown is filtered correctly even when Type starts prefilled.
+- Keep the existing behavior that clears `parent_id` when Type changes.
+
+## Data Flow
+
+1. User selects a category tab on the Categories list.
+2. User clicks Create.
+3. Navigation carries explicit context (`source`, `type`) in the query string.
+4. Category create form initializes Type when the context is valid.
+5. The parent-category dropdown immediately filters to the selected type.
+6. User completes the form and saves.
+
+## Error Handling and Safety
+
+- Invalid `type` query value: ignored.
+- Missing or unexpected `source`: ignored.
+- No fallback inference from location history or heuristics.
+- Required Type validation remains the final guard if no valid prefill exists.
+
+## Testing Plan
+
+Add/update targeted e2e coverage for:
+
+1. From Categories list with selected tab:
+   - create page opens with matching Type preselected.
+2. Direct `/categories/create`:
+   - Type is not preselected.
+3. Invalid query params:
+   - Type is not preselected.
+4. Prefilled Type on create:
+   - parent-category dropdown is available without needing a manual type change first.
+
+## Trade-offs
+
+- Query params make context explicit and robust across refresh/share.
+- URL becomes slightly more verbose, but the behavior stays easy to debug.
+- Manual URL editing can trigger prefill, but only through explicit, validated parameters.
+
+## Success Criteria
+
+- Clicking Create from the Categories list preserves the selected tab type into the create form.
+- Create from other app pages still requires an explicit type choice.
+- Existing create/edit flows and parent-category filtering remain unchanged.


### PR DESCRIPTION
## Why

Users had to reselect the category type when creating a new category, even after choosing a category tab on the Categories page. This makes the create flow slower than it needs to be. Fixes #221.

## What Changed

- Files or areas updated:
  - `apps/web-next/src/pages/categories/list.tsx`
  - `apps/web-next/src/pages/categories/create.tsx`
  - `apps/web-next/e2e/tests/categories.spec.ts`
  - `apps/web-next/e2e/utils/test-helpers.ts`
- New functionality added:
  - The Categories list Create button now carries the active tab type into `/categories/create`.
  - The category create form preselects Type only when it comes from the Categories list context.
  - The parent category dropdown is driven by the form's current type so it is ready on first render.
  - E2E coverage now checks prefill, blank direct create, invalid params, and dropdown readiness.
- Existing behavior changed:
  - Direct `/categories/create` visits remain blank.
  - The shared category create helper now handles already-prefilled Type values.

## Key Decisions

- Decision: use query params for explicit context handoff.
- Reasoning: it keeps the behavior predictable, debuggable, and aligned with the existing transaction prefill flow.
- Alternatives considered: shared UI state and persistent last-used type, both of which were broader than the issue asked for.

## How This Affects the System

- User-facing changes:
  - Creating a category from a selected tab is faster because Type is prefilled.
- API changes:
  - None.
- Performance implications:
  - None meaningful.
- Database changes:
  - None.
- Breaking changes:
  - None.

## Testing

- New tests added:
  - `create from selected category tab preselects type`
  - `direct create stays blank`
  - `invalid query params stay blank`
- Existing tests status:
  - Full `categories.spec.ts` suite passes.
- Manual testing performed:
  - Verified Create from each tab, direct `/categories/create`, and invalid query params.
- Edge cases tested:
  - Prefilled Type does not break the parent-category dropdown.
- Test files modified or added:
  - `apps/web-next/e2e/tests/categories.spec.ts`
  - `apps/web-next/e2e/utils/test-helpers.ts`
