### PR TITLE
feat(web-next): center selected pages with shared width wrapper

### DIFF
--- a/apps/web-next/e2e/tests/content-width.spec.ts
+++ b/apps/web-next/e2e/tests/content-width.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from "@playwright/test";
+import { createTestUser, deleteTestUser, loginUser } from "../utils/test-helpers";
+
+test.describe("Content width shell", () => {
+  test("selected authenticated pages use the shared width shell", async ({
+    page,
+  }) => {
+    const { email, password, userId } = await createTestUser();
+
+    try {
+      await loginUser(page, email, password);
+
+      for (const path of [
+        "/transactions",
+        "/categories",
+        "/budgets",
+        "/tags",
+        "/settings",
+      ]) {
+        await page.goto(path);
+
+        const shell = page.getByTestId("page-width-shell");
+        await expect(shell).toBeVisible();
+        await expect(shell).toHaveCSS("max-width", "1200px");
+      }
+    } finally {
+      await deleteTestUser(userId);
+    }
+  });
+
+  test("login page does not use the shared width shell", async ({ page }) => {
+    await page.goto("/login");
+
+    await expect(page.getByTestId("page-width-shell")).toHaveCount(0);
+  });
+});

--- a/apps/web-next/e2e/tests/content-width.spec.ts
+++ b/apps/web-next/e2e/tests/content-width.spec.ts
@@ -14,6 +14,7 @@ test.describe("Content width shell", () => {
         "/transactions",
         "/categories",
         "/budgets",
+        "/bank-accounts",
         "/tags",
         "/settings",
       ]) {

--- a/apps/web-next/src/App.tsx
+++ b/apps/web-next/src/App.tsx
@@ -231,10 +231,18 @@ function App() {
                     </Route>
 
                     <Route path="bank-accounts">
-                      <Route index element={<BankAccountList />} />
-                      <Route path="create" element={<BankAccountCreate />} />
-                      <Route path="edit/:id" element={<BankAccountEdit />} />
-                      <Route path="show/:id" element={<BankAccountShow />} />
+                      <Route
+                        element={
+                          <PageWidthShell>
+                            <Outlet />
+                          </PageWidthShell>
+                        }
+                      >
+                        <Route index element={<BankAccountList />} />
+                        <Route path="create" element={<BankAccountCreate />} />
+                        <Route path="edit/:id" element={<BankAccountEdit />} />
+                        <Route path="show/:id" element={<BankAccountShow />} />
+                      </Route>
                     </Route>
 
                     <Route path="tags">

--- a/apps/web-next/src/App.tsx
+++ b/apps/web-next/src/App.tsx
@@ -61,7 +61,12 @@ import {
 } from "./pages/categories";
 import { SettingsPage } from "./pages/settings";
 import { ProjectTitle } from "./components/title";
-import { Header, EnvironmentBanner, ErrorBoundary } from "./components";
+import {
+  Header,
+  EnvironmentBanner,
+  ErrorBoundary,
+  PageWidthShell,
+} from "./components";
 
 const I18N_TRANSLATIONS: Record<string, string> = {
   "documentTitle.default": "MoneyLens",
@@ -196,17 +201,33 @@ function App() {
                   >
                     <Route index element={<DashboardPage />} />
                     <Route path="transactions">
-                      <Route index element={<TransactionList />} />
-                      <Route path="create" element={<TransactionCreate />} />
-                      <Route path="edit/:id" element={<TransactionEdit />} />
-                      <Route path="show/:id" element={<TransactionShow />} />
+                      <Route
+                        element={
+                          <PageWidthShell>
+                            <Outlet />
+                          </PageWidthShell>
+                        }
+                      >
+                        <Route index element={<TransactionList />} />
+                        <Route path="create" element={<TransactionCreate />} />
+                        <Route path="edit/:id" element={<TransactionEdit />} />
+                        <Route path="show/:id" element={<TransactionShow />} />
+                      </Route>
                     </Route>
 
                     <Route path="categories">
-                      <Route index element={<CategoryList />} />
-                      <Route path="create" element={<CategoryCreate />} />
-                      <Route path="edit/:id" element={<CategoryEdit />} />
-                      <Route path="show/:id" element={<CategoryShow />} />
+                      <Route
+                        element={
+                          <PageWidthShell>
+                            <Outlet />
+                          </PageWidthShell>
+                        }
+                      >
+                        <Route index element={<CategoryList />} />
+                        <Route path="create" element={<CategoryCreate />} />
+                        <Route path="edit/:id" element={<CategoryEdit />} />
+                        <Route path="show/:id" element={<CategoryShow />} />
+                      </Route>
                     </Route>
 
                     <Route path="bank-accounts">
@@ -217,20 +238,43 @@ function App() {
                     </Route>
 
                     <Route path="tags">
-                      <Route index element={<TagList />} />
-                      <Route path="create" element={<TagCreate />} />
-                      <Route path="edit/:id" element={<TagEdit />} />
-                      <Route path="show/:id" element={<TagShow />} />
+                      <Route
+                        element={
+                          <PageWidthShell>
+                            <Outlet />
+                          </PageWidthShell>
+                        }
+                      >
+                        <Route index element={<TagList />} />
+                        <Route path="create" element={<TagCreate />} />
+                        <Route path="edit/:id" element={<TagEdit />} />
+                        <Route path="show/:id" element={<TagShow />} />
+                      </Route>
                     </Route>
 
                     <Route path="budgets">
-                      <Route index element={<BudgetList />} />
-                      <Route path="create" element={<BudgetCreate />} />
-                      <Route path="edit/:id" element={<BudgetEdit />} />
-                      <Route path="show/:id" element={<BudgetShow />} />
+                      <Route
+                        element={
+                          <PageWidthShell>
+                            <Outlet />
+                          </PageWidthShell>
+                        }
+                      >
+                        <Route index element={<BudgetList />} />
+                        <Route path="create" element={<BudgetCreate />} />
+                        <Route path="edit/:id" element={<BudgetEdit />} />
+                        <Route path="show/:id" element={<BudgetShow />} />
+                      </Route>
                     </Route>
 
-                    <Route path="settings" element={<SettingsPage />} />
+                    <Route
+                      path="settings"
+                      element={
+                        <PageWidthShell>
+                          <SettingsPage />
+                        </PageWidthShell>
+                      }
+                    />
                   </Route>
 
                   <Route

--- a/apps/web-next/src/components/index.ts
+++ b/apps/web-next/src/components/index.ts
@@ -2,6 +2,7 @@ export { Header } from "./header";
 export { EnvironmentBanner } from "./environment-banner";
 export { ErrorBoundary } from "./error-boundary";
 export { EmptyState } from "./EmptyState";
+export { PageWidthShell } from "./page-width-shell";
 export {
   getTransactionEmptyState,
   getBudgetEmptyState,

--- a/apps/web-next/src/components/page-width-shell/index.tsx
+++ b/apps/web-next/src/components/page-width-shell/index.tsx
@@ -1,0 +1,16 @@
+import type { PropsWithChildren } from "react";
+
+export const PageWidthShell = ({ children }: PropsWithChildren) => {
+  return (
+    <div
+      data-testid="page-width-shell"
+      style={{
+        width: "100%",
+        maxWidth: 1200,
+        margin: "0 auto",
+      }}
+    >
+      {children}
+    </div>
+  );
+};

--- a/docs/superpowers/plans/2026-07-12-content-width-wrapper.md
+++ b/docs/superpowers/plans/2026-07-12-content-width-wrapper.md
@@ -1,0 +1,234 @@
+# Content Width Wrapper Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Center the selected MoneyLens authenticated pages inside a shared finefoods-style max-width wrapper without changing auth pages or the dashboard.
+
+**Architecture:** Add one reusable wrapper component that owns the width constraint and applies it at the route boundary. Wire that wrapper only around transactions, categories, budgets, tags, and settings so the page internals stay untouched and the layout decision stays centralized.
+
+**Tech Stack:** React 19, React Router, Refine, Ant Design, Playwright.
+
+---
+
+### Task 1: Adding a shared page-width wrapper component
+
+**Files:**
+- Create: `apps/web-next/src/components/page-width-shell/index.tsx`
+- Modify: `apps/web-next/src/components/index.ts`
+
+- [ ] **Step 1: Add the wrapper component**
+
+```tsx
+import type { PropsWithChildren } from "react";
+
+export const PageWidthShell = ({ children }: PropsWithChildren) => {
+  return (
+    <div
+      data-testid="page-width-shell"
+      style={{
+        width: "100%",
+        maxWidth: 1200,
+        margin: "0 auto",
+      }}
+    >
+      {children}
+    </div>
+  );
+};
+```
+
+- [ ] **Step 2: Export the wrapper from the component barrel**
+
+```ts
+export { PageWidthShell } from "./page-width-shell";
+```
+
+- [ ] **Step 3: Run a focused type-check on the new component export**
+
+Run: `cd apps/web-next && npm run check-types`
+Expected: PASS
+
+- [ ] **Step 4: Commit the wrapper component**
+
+```bash
+git add apps/web-next/src/components/page-width-shell/index.tsx apps/web-next/src/components/index.ts
+git commit -m "feat(web-next): add shared page width shell"
+```
+
+### Task 2: Wrapping only the selected authenticated pages
+
+**Files:**
+- Modify: `apps/web-next/src/App.tsx`
+
+- [ ] **Step 1: Wrap the selected route groups with `PageWidthShell`**
+
+```tsx
+import { PageWidthShell } from "./components";
+
+// ...
+
+<Route
+  path="transactions"
+  element={
+    <PageWidthShell>
+      <Outlet />
+    </PageWidthShell>
+  }
+>
+  <Route index element={<TransactionList />} />
+  <Route path="create" element={<TransactionCreate />} />
+  <Route path="edit/:id" element={<TransactionEdit />} />
+  <Route path="show/:id" element={<TransactionShow />} />
+</Route>
+
+<Route
+  path="categories"
+  element={
+    <PageWidthShell>
+      <Outlet />
+    </PageWidthShell>
+  }
+>
+  <Route index element={<CategoryList />} />
+  <Route path="create" element={<CategoryCreate />} />
+  <Route path="edit/:id" element={<CategoryEdit />} />
+  <Route path="show/:id" element={<CategoryShow />} />
+</Route>
+
+<Route
+  path="budgets"
+  element={
+    <PageWidthShell>
+      <Outlet />
+    </PageWidthShell>
+  }
+>
+  <Route index element={<BudgetList />} />
+  <Route path="create" element={<BudgetCreate />} />
+  <Route path="edit/:id" element={<BudgetEdit />} />
+  <Route path="show/:id" element={<BudgetShow />} />
+</Route>
+
+<Route
+  path="tags"
+  element={
+    <PageWidthShell>
+      <Outlet />
+    </PageWidthShell>
+  }
+>
+  <Route index element={<TagList />} />
+  <Route path="create" element={<TagCreate />} />
+  <Route path="edit/:id" element={<TagEdit />} />
+  <Route path="show/:id" element={<TagShow />} />
+</Route>
+
+<Route
+  path="settings"
+  element={
+    <PageWidthShell>
+      <SettingsPage />
+    </PageWidthShell>
+  }
+/>
+```
+
+- [ ] **Step 2: Leave the dashboard and auth route trees unchanged**
+
+Do not add the wrapper around the dashboard index route or any `/login`, `/register`, `/forgot-password`, or `/update-password` route.
+
+- [ ] **Step 3: Run a focused type-check**
+
+Run: `cd apps/web-next && npm run check-types`
+Expected: PASS
+
+- [ ] **Step 4: Commit the route wiring**
+
+```bash
+git add apps/web-next/src/App.tsx
+git commit -m "feat(web-next): center selected authenticated pages"
+```
+
+### Task 3: Adding Playwright coverage for wrapped and unwrapped pages
+
+**Files:**
+- Create: `apps/web-next/e2e/tests/content-width.spec.ts`
+
+- [ ] **Step 1: Write the failing Playwright smoke test**
+
+```ts
+import { test, expect } from "@playwright/test";
+import { createTestUser, deleteTestUser, loginUser } from "../utils/test-helpers";
+
+test.describe("Content width shell", () => {
+  test("selected authenticated pages use the shared width shell", async ({ page }) => {
+    const { email, password, userId } = await createTestUser();
+
+    try {
+      await loginUser(page, email, password);
+
+      for (const path of [
+        "/transactions",
+        "/categories",
+        "/budgets",
+        "/tags",
+        "/settings",
+      ]) {
+        await page.goto(path);
+
+        const shell = page.getByTestId("page-width-shell");
+        await expect(shell).toBeVisible();
+        await expect(shell).toHaveCSS("max-width", "1200px");
+      }
+    } finally {
+      await deleteTestUser(userId);
+    }
+  });
+
+  test("login page does not use the shared width shell", async ({ page }) => {
+    await page.goto("/login");
+
+    await expect(page.getByTestId("page-width-shell")).toHaveCount(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run the new spec and confirm it fails before implementation is finished**
+
+Run: `cd apps/web-next && npm run test:e2e:ci -- e2e/tests/content-width.spec.ts`
+Expected: FAIL until Tasks 1 and 2 are complete
+
+- [ ] **Step 3: After the wrapper and route wiring are in place, rerun the same spec**
+
+Run: `cd apps/web-next && npm run test:e2e:ci -- e2e/tests/content-width.spec.ts`
+Expected: PASS
+
+- [ ] **Step 4: Commit the test coverage**
+
+```bash
+git add apps/web-next/e2e/tests/content-width.spec.ts
+git commit -m "test(web-next): cover centered page width shell"
+```
+
+### Task 4: Final validation
+
+**Files:**
+- None
+
+- [ ] **Step 1: Run the repo checks that cover the changed surface**
+
+Run:
+```bash
+cd apps/web-next
+npm run check-types
+npm run lint -- src/App.tsx src/components/page-width-shell/index.tsx e2e/tests/content-width.spec.ts
+npm run test:e2e:ci -- e2e/tests/content-width.spec.ts
+```
+Expected: all pass
+
+- [ ] **Step 2: Confirm the visual scope matches the spec**
+
+Check that `/transactions`, `/categories`, `/budgets`, `/tags`, and `/settings` are centered, while `/login` and `/` are unchanged.
+
+- [ ] **Step 3: Commit any final adjustments**
+If validation finds a small follow-up fix, commit only the touched files with explicit paths and keep the commit message scoped to that fix.

--- a/docs/superpowers/plans/2026-07-12-content-width-wrapper.md
+++ b/docs/superpowers/plans/2026-07-12-content-width-wrapper.md
@@ -4,7 +4,7 @@
 
 **Goal:** Center the selected MoneyLens authenticated pages inside a shared finefoods-style max-width wrapper without changing auth pages or the dashboard.
 
-**Architecture:** Add one reusable wrapper component that owns the width constraint and applies it at the route boundary. Wire that wrapper only around transactions, categories, budgets, tags, and settings so the page internals stay untouched and the layout decision stays centralized.
+**Architecture:** Add one reusable wrapper component that owns the width constraint and applies it at the route boundary. Wire that wrapper only around transactions, categories, budgets, bank accounts, tags, and settings so the page internals stay untouched and the layout decision stays centralized.
 
 **Tech Stack:** React 19, React Router, Refine, Ant Design, Playwright.
 
@@ -171,6 +171,7 @@ test.describe("Content width shell", () => {
         "/transactions",
         "/categories",
         "/budgets",
+        "/bank-accounts",
         "/tags",
         "/settings",
       ]) {
@@ -228,7 +229,7 @@ Expected: all pass
 
 - [ ] **Step 2: Confirm the visual scope matches the spec**
 
-Check that `/transactions`, `/categories`, `/budgets`, `/tags`, and `/settings` are centered, while `/login` and `/` are unchanged.
+Check that `/transactions`, `/categories`, `/budgets`, `/bank-accounts`, `/tags`, and `/settings` are centered, while `/login` and `/` are unchanged.
 
 - [ ] **Step 3: Commit any final adjustments**
 If validation finds a small follow-up fix, commit only the touched files with explicit paths and keep the commit message scoped to that fix.

--- a/docs/superpowers/specs/2026-07-12-content-width-wrapper-design.md
+++ b/docs/superpowers/specs/2026-07-12-content-width-wrapper-design.md
@@ -9,7 +9,7 @@ The web-next app currently lets several authenticated resource pages expand to t
 ## Goals
 
 1. Center the main content for selected MoneyLens pages with a finefoods-style width cap.
-2. Apply the change only to transactions, categories, budgets, tags, and settings pages.
+2. Apply the change only to transactions, categories, budgets, bank accounts, tags, and settings pages.
 3. Leave authentication pages and the dashboard unchanged.
 4. Keep the change shared and reusable instead of repeating page-specific width styles.
 
@@ -27,6 +27,7 @@ Add one shared page wrapper component that constrains width, centers content, an
 - `transactions`
 - `categories`
 - `budgets`
+- `bank-accounts`
 - `tags`
 - `settings`
 

--- a/docs/superpowers/specs/2026-07-12-content-width-wrapper-design.md
+++ b/docs/superpowers/specs/2026-07-12-content-width-wrapper-design.md
@@ -1,0 +1,45 @@
+# Content Width Wrapper Design
+
+**Status:** Draft
+
+## Context
+
+The web-next app currently lets several authenticated resource pages expand to the full available viewport width. That makes list, show, create, edit, and settings screens feel wider than the equivalent pages in `apps/finefoods-antd`, where the main content is centered inside a fixed-width wrapper.
+
+## Goals
+
+1. Center the main content for selected MoneyLens pages with a finefoods-style width cap.
+2. Apply the change only to transactions, categories, budgets, tags, and settings pages.
+3. Leave authentication pages and the dashboard unchanged.
+4. Keep the change shared and reusable instead of repeating page-specific width styles.
+
+## Non-goals
+
+1. No redesign of page internals.
+2. No changes to dashboard layout.
+3. No changes to login/register/forgot-password/update-password pages.
+4. No table, form, or card component refactors beyond what is needed for the shared wrapper.
+
+## Proposed Design
+
+Add one shared page wrapper component that constrains width, centers content, and preserves responsive behavior on small screens. Use it only for the selected route groups/pages:
+
+- `transactions`
+- `categories`
+- `budgets`
+- `tags`
+- `settings`
+
+The wrapper should behave like the finefoods layout: full width on mobile, centered on larger screens, and capped at a consistent max width. The dashboard and auth routes should continue using their current layout.
+
+## Implementation Notes
+
+- Prefer a single reusable component over duplicated inline styles.
+- Apply the wrapper at the route/page boundary so the rest of the page code stays untouched.
+- Keep the width value explicit and easy to adjust if the design needs to be nudged later.
+
+## Validation
+
+1. Open the affected list/show/create/edit/settings pages and confirm the content is centered and narrower.
+2. Confirm auth pages remain full screen as they are today.
+3. Confirm the dashboard layout is unchanged.


### PR DESCRIPTION
## Why
Several web-next pages (transactions, categories, budgets, bank accounts, tags, settings) were stretching across the full available width, which made content feel dense compared to the finefoods layout style. This change applies a consistent centered width cap to those pages while intentionally keeping dashboard and auth pages unchanged.

## What Changed
Implemented a shared page-width wrapper and applied it to selected routes, plus added focused E2E coverage.

- Files or areas updated:
  - `apps/web-next/src/components/page-width-shell/index.tsx`
  - `apps/web-next/src/components/index.ts`
  - `apps/web-next/src/App.tsx`
  - `apps/web-next/e2e/tests/content-width.spec.ts`
  - `docs/superpowers/specs/2026-07-12-content-width-wrapper-design.md`
  - `docs/superpowers/plans/2026-07-12-content-width-wrapper.md`
- New functionality added:
  - Shared `PageWidthShell` (`maxWidth: 1200`, centered) for route-level layout control.
  - Playwright smoke test that verifies wrapped routes and confirms `/login` is not wrapped.
- Existing behavior changed:
  - Route groups `transactions`, `categories`, `budgets`, `bank-accounts`, `tags`, and `settings` now render inside the shared centered shell.

## Key Decisions
- Decision:
  - Apply width control at route boundaries instead of modifying individual pages/components.
- Reasoning:
  - Keeps behavior centralized, consistent, and easy to adjust without duplicating style logic.
- Alternatives considered:
  - Per-page inline width styles (rejected due to duplication/drift).
  - Broad layout-level wrapper (rejected because dashboard/auth must stay unchanged).

## How This Affects the System
- User-facing changes:
  - Selected pages are visually narrower and centered.
- API changes:
  - None.
- Performance implications:
  - Negligible; one lightweight wrapper element.
- Database changes:
  - None.
- Breaking changes:
  - None.

## Testing
- New tests added:
  - `apps/web-next/e2e/tests/content-width.spec.ts`
- Existing tests status:
  - Targeted typecheck/lint and new Playwright smoke test pass.
- Manual testing performed:
  - Verified selected route wrappers via browser and route configuration.
- Edge cases tested:
  - `/login` remains unwrapped.
- Test files modified or added:
  - Added `apps/web-next/e2e/tests/content-width.spec.ts`