### PR TITLE
fix: close IDOR in get_transaction_tags and enforce category ownership

### DIFF
--- a/supabase/migrations/20260718204224_fix_transaction_tags_idor_and_category_ownership.sql
+++ b/supabase/migrations/20260718204224_fix_transaction_tags_idor_and_category_ownership.sql
@@ -1,0 +1,51 @@
+-- S1: get_transaction_tags had no ownership check, allowing any authenticated user to read
+-- another user's tags for a known transaction id (IDOR).
+CREATE
+OR REPLACE FUNCTION public.get_transaction_tags (p_transaction_id UUID) RETURNS jsonb LANGUAGE SQL STABLE SECURITY DEFINER
+SET
+  search_path = '' AS $$
+    SELECT COALESCE(
+        jsonb_agg(
+            jsonb_build_object(
+                'id', t.id,
+                'name', t.name,
+                'description', t.description
+            ) ORDER BY t.name
+        ) FILTER (WHERE t.id IS NOT NULL),
+        '[]'::jsonb
+    )
+    FROM public.transaction_tags tt
+    JOIN public.tags t ON tt.tag_id = t.id
+    WHERE tt.transaction_id = p_transaction_id
+      AND EXISTS (
+        SELECT 1 FROM public.transactions t2
+        WHERE t2.id = p_transaction_id AND t2.user_id = auth.uid()
+      );
+$$;
+
+-- S2: check_transaction_category_type validated the category's type but never verified the
+-- category belongs to the transaction's user, allowing a transaction to reference another
+-- user's category.
+CREATE
+OR REPLACE FUNCTION public.check_transaction_category_type () RETURNS TRIGGER LANGUAGE plpgsql
+SET
+  search_path = '' AS $$
+DECLARE
+  v_category_type public.transaction_type;
+  v_category_user_id uuid;
+BEGIN
+  IF NEW.category_id IS NOT NULL THEN
+    SELECT type, user_id INTO v_category_type, v_category_user_id
+    FROM public.categories WHERE id = NEW.category_id;
+
+    IF v_category_user_id IS DISTINCT FROM NEW.user_id THEN
+      RAISE EXCEPTION 'Category does not belong to the user' USING ERRCODE = '23514';
+    END IF;
+
+    IF NEW.type IS DISTINCT FROM v_category_type THEN
+      RAISE EXCEPTION 'Transaction type (%) does not match category type (%)', NEW.type, v_category_type;
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;

--- a/supabase/tests/transaction_tags_test.sql
+++ b/supabase/tests/transaction_tags_test.sql
@@ -2,7 +2,7 @@ begin;
 
 create extension if not exists pgtap with schema extensions;
 
-select plan(17);
+select plan(18);
 
 -- Create two test users
 select tests.create_supabase_user('tx_user1@test.com');
@@ -167,6 +167,15 @@ SELECT results_eq(
 SELECT is_empty(
   $$ UPDATE public.transaction_tags SET created_at = now() WHERE transaction_id IN (SELECT id FROM public.transactions WHERE user_id = tests.get_supabase_uid('tx_user1@test.com')) RETURNING 1 $$,
   'User2 cannot update User1 transaction_tags'
+);
+
+-- 11) IDOR: User2 cannot read User1's transaction tags via get_transaction_tags RPC
+SELECT results_eq(
+  $$ SELECT public.get_transaction_tags(
+      (SELECT id FROM public.transactions WHERE user_id = tests.get_supabase_uid('tx_user1@test.com') AND date = '2025-01-03' LIMIT 1)
+    ) $$,
+  $$ SELECT '[]'::jsonb $$,
+  'User2 cannot read User1 transaction tags via get_transaction_tags'
 );
 
 -- Finish

--- a/supabase/tests/transactions_rls_test.sql
+++ b/supabase/tests/transactions_rls_test.sql
@@ -2,7 +2,7 @@ begin;
 
 create extension if not exists pgtap with schema extensions;
 
-select plan(8);
+select plan(10);
 
 -- Create test supabase users
 select tests.create_supabase_user('user1@test.com');
@@ -16,6 +16,17 @@ values
     (tests.get_supabase_uid('user1@test.com'), 'stocks'),
     (tests.get_supabase_uid('user2@test.com'), 'salary'),
     (tests.get_supabase_uid('user2@test.com'), 'groceries');
+
+-- Seed a category per user for the category-ownership tests
+insert into public.categories (user_id, type, name)
+values
+    (tests.get_supabase_uid('user1@test.com'), 'spend', 'user1-cat'),
+    (tests.get_supabase_uid('user2@test.com'), 'spend', 'user2-cat');
+
+-- Capture user1's category id up front (as postgres, bypassing RLS) since User 2 can't
+-- see it once authenticated below.
+select id as user1_cat_id from public.categories
+    where user_id = tests.get_supabase_uid('user1@test.com') and name = 'user1-cat' \gset
 
 -- Create test transactions
 insert into transactions (id, user_id, date, type, category, amount, tags, notes, bank_account) values
@@ -95,6 +106,43 @@ select throws_ok(
     '42501',
     'new row violates row-level security policy for table "transactions"',
     'User 2 should not be able to set user_id to another user on insert'
+);
+
+
+-- Test 9: User 2 cannot insert a transaction referencing User 1's category
+select throws_ok(
+        format(
+            $$insert into transactions (id, user_id, date, type, category_id, amount, notes)
+                values (
+                    gen_random_uuid(),
+                    tests.get_supabase_uid('user2@test.com'),
+                    current_date,
+                    'spend',
+                    %L,
+                    50.00,
+                    'category ownership check'
+                )$$,
+            :'user1_cat_id'
+        ),
+    '23514',
+    'Category does not belong to the user',
+    'User 2 should not be able to insert a transaction with User 1''s category_id'
+);
+
+
+-- Test 10: User 2 can insert a transaction referencing their own category
+select lives_ok(
+    $$insert into transactions (id, user_id, date, type, category_id, amount, notes)
+        values (
+            gen_random_uuid(),
+            tests.get_supabase_uid('user2@test.com'),
+            current_date,
+            'spend',
+            (select id from public.categories where user_id = tests.get_supabase_uid('user2@test.com') and name = 'user2-cat'),
+            50.00,
+            'own category'
+        )$$,
+    'User 2 should be able to insert a transaction with their own category_id'
 );
 
 select * from finish();


### PR DESCRIPTION
## Summary
- **S1 (IDOR):** `get_transaction_tags(p_transaction_id)` had no ownership check — any authenticated user could read another user's tags for a known transaction id. Added an `EXISTS` predicate verifying `transactions.user_id = auth.uid()` before returning tags (returns `'[]'::jsonb` for anything not owned, matching its existing "not found" shape).
- **S2 (category ownership):** the `check_transaction_category_type` trigger validated a transaction's `type` against its `category_id`'s type but never checked that the category belonged to the transaction's `user_id`, allowing a transaction to reference another user's category. Added an ownership check (`category.user_id = NEW.user_id`), raising `23514` on mismatch — mirrors the existing `check_transaction_bank_account` trigger pattern.
- New migration: `supabase/migrations/20260718204224_fix_transaction_tags_idor_and_category_ownership.sql`.

Source: `docs/superpowers/plans/2026-07-18-security-review-fixes.md` §S1+S2.

## Test plan
- [x] `supabase/tests/transaction_tags_test.sql` — added a case verifying User 2 gets `[]` back from `get_transaction_tags` for User 1's transaction.
- [x] `supabase/tests/transactions_rls_test.sql` — added cases verifying User 2 cannot insert a transaction referencing User 1's category (`23514`), and can insert one referencing their own category.
- [x] `supabase db reset` + `supabase test db` — full pgTAP suite passes (208/208).
- [x] `supabase db lint` — no issues in the `public` schema (pre-existing warnings are all internal to the `pgtap`/`extensions` schema, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)