### PR TITLE
docs: instruct agents to use the create-pull-request skill for PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ This file provides guidance to AI agents when working with code in this reposito
 - **NEVER commit directly to `main` or `release` branches.** Always create a feature branch for any code changes.
 - Only commit to `main` or `release` if the user explicitly instructs you to do so in that message.
 - Default workflow: create a branch → commit → open a PR.
+- **When opening a PR, use the `create-pull-request` skill** rather than running `git push` + `gh pr create` manually — invoke it whenever the user asks to create/open/submit a PR, ship, or send changes for review.
 
 ## Repository Structure
 


### PR DESCRIPTION
## Why

The AGENTS.md git workflow section described the branch → commit → PR flow generically, without pointing at the repo's `create-pull-request` skill. As a result, PRs were being opened manually via `git push` + `gh pr create`, bypassing the skill's template lookup and confirmation steps.

## What Changed

- Files or areas updated: `AGENTS.md`
- New functionality added: N/A (docs only)
- Existing behavior changed: Added a bullet to the Git Workflow section instructing agents to use the `create-pull-request` skill when opening a PR, rather than running the git/gh commands manually.

## Key Decisions

- Decision: Added a single bullet rather than a new section, to keep it inline with the existing critical-rules list.
- Reasoning: The rule is a natural extension of the existing branch/commit/PR workflow rules already in that block.
- Alternatives considered: A separate "PR workflow" section — skipped as overkill for one line.

## How This Affects the System

- User-facing changes: None
- API changes: None
- Performance implications: None
- Database changes: None
- Breaking changes: None

## Testing

- New tests added: N/A (docs only)
- Existing tests status: N/A
- Manual testing performed: Read back the updated AGENTS.md section for clarity
- Edge cases tested: N/A
- Test files modified or added: None