### PR TITLE
fix: enforce NOT NULL and ON DELETE CASCADE on transactions.user_id (S4)

### DIFF
--- a/docs/superpowers/plans/2026-07-18-security-review-fixes.md
+++ b/docs/superpowers/plans/2026-07-18-security-review-fixes.md
@@ -10,7 +10,7 @@ All findings below were re-verified directly against the current repo (not just 
 
 ## Should-fix items
 
-### S1 + S2 — one migration: `supabase/migrations/20260718000000_fix_transaction_tags_idor_and_category_ownership.sql`
+### ✅ Done — S1 + S2 — one migration: `supabase/migrations/20260718204224_fix_transaction_tags_idor_and_category_ownership.sql`
 
 **S1 — `get_transaction_tags` IDOR.**
 Current definition, `supabase/migrations/20260201164000_baseline_from_schemas.sql:1250-1267` (only definition anywhere — confirmed no later migration overrides it), is `LANGUAGE SQL SECURITY DEFINER` with no ownership check at all:
@@ -103,7 +103,7 @@ $$;
 
 ---
 
-### S4 — `supabase/migrations/20260718000100_transactions_user_id_not_null_cascade.sql`
+### ✅ Done — S4 — `supabase/migrations/20260718205739_transactions_user_id_not_null_cascade.sql`
 
 Current column definition, baseline file lines 130-145:
 ```sql

--- a/supabase/migrations/20260718205739_transactions_user_id_not_null_cascade.sql
+++ b/supabase/migrations/20260718205739_transactions_user_id_not_null_cascade.sql
@@ -1,0 +1,7 @@
+-- S4: transactions.user_id was nullable with no ON DELETE action, unlike every other
+-- user-owned table (categories, bank_accounts, tags, budgets, user_settings), which are
+-- all NOT NULL ... REFERENCES auth.users (id) ON DELETE CASCADE.
+alter table public.transactions drop constraint transactions_user_id_fkey;
+alter table public.transactions alter column user_id set not null;
+alter table public.transactions
+  add constraint transactions_user_id_fkey foreign key (user_id) references auth.users (id) on delete cascade;

--- a/supabase/tests/transactions_rls_test.sql
+++ b/supabase/tests/transactions_rls_test.sql
@@ -2,7 +2,7 @@ begin;
 
 create extension if not exists pgtap with schema extensions;
 
-select plan(10);
+select plan(12);
 
 -- Create test supabase users
 select tests.create_supabase_user('user1@test.com');
@@ -143,6 +143,35 @@ select lives_ok(
             'own category'
         )$$,
     'User 2 should be able to insert a transaction with their own category_id'
+);
+
+-- Test 11: user_id is NOT NULL (S4)
+-- Bypass RLS entirely (reset role + clear the JWT claim) so the insert fails on the
+-- NOT NULL constraint itself rather than on the RLS policy's NULL = NULL check.
+reset role;
+select set_config('request.jwt.claims', '', true);
+
+select throws_ok(
+        $$insert into transactions (id, user_id, date, type, category, amount, tags, notes, bank_account)
+            values (gen_random_uuid(), null, current_date, 'spend', 'groceries', 50.00, null, 'no owner', 'test bank')$$,
+    '23502',
+    'null value in column "user_id" of relation "transactions" violates not-null constraint',
+    'Inserting a transaction with a null user_id should violate the NOT NULL constraint'
+);
+
+
+-- Test 12: deleting the owning auth user cascades to their transactions (S4)
+select tests.create_supabase_user('cascade_user@test.com');
+
+insert into transactions (id, user_id, date, type, category, amount, tags, notes, bank_account)
+values (gen_random_uuid(), tests.get_supabase_uid('cascade_user@test.com'), current_date, 'spend', 'groceries', 25.00, null, 'will cascade', 'test bank');
+
+delete from auth.users where id = tests.get_supabase_uid('cascade_user@test.com');
+
+select results_eq(
+    $$select count(*) from transactions where notes = 'will cascade'$$,
+    array[0::bigint],
+    'Deleting the owning auth user should cascade-delete their transactions'
 );
 
 select * from finish();

--- a/types.gen.ts
+++ b/types.gen.ts
@@ -420,7 +420,7 @@ export type Database = {
           tags: string[] | null
           type: Database["public"]["Enums"]["transaction_type"]
           updated_at: string
-          user_id: string | null
+          user_id: string
         }
         Insert: {
           amount: number
@@ -436,7 +436,7 @@ export type Database = {
           tags?: string[] | null
           type: Database["public"]["Enums"]["transaction_type"]
           updated_at?: string
-          user_id?: string | null
+          user_id: string
         }
         Update: {
           amount?: number
@@ -452,7 +452,7 @@ export type Database = {
           tags?: string[] | null
           type?: Database["public"]["Enums"]["transaction_type"]
           updated_at?: string
-          user_id?: string | null
+          user_id?: string
         }
         Relationships: [
           {
@@ -864,7 +864,7 @@ export type Database = {
           tags: string[] | null
           type: Database["public"]["Enums"]["transaction_type"]
           updated_at: string
-          user_id: string | null
+          user_id: string
         }
         SetofOptions: {
           from: "*"
@@ -962,7 +962,7 @@ export type Database = {
           tags: string[] | null
           type: Database["public"]["Enums"]["transaction_type"]
           updated_at: string
-          user_id: string | null
+          user_id: string
         }
         SetofOptions: {
           from: "*"


### PR DESCRIPTION
## Why

S4 from the security review (docs/superpowers/plans/2026-07-18-security-review-fixes.md). transactions.user_id was nullable with no ON DELETE action, unlike every other user-owned table (categories, bank_accounts, tags, budgets, user_settings), which are all NOT NULL ... REFERENCES auth.users (id) ON DELETE CASCADE. This left the door open for orphaned/ownerless transaction rows and meant deleting an auth user didn't clean up their transactions.

## What Changed

- Files or areas updated: supabase/migrations/20260718205739_transactions_user_id_not_null_cascade.sql, supabase/tests/transactions_rls_test.sql, types.gen.ts, docs/superpowers/plans/2026-07-18-security-review-fixes.md
- New functionality added: none
- Existing behavior changed: transactions.user_id is now NOT NULL and its FK to auth.users(id) is ON DELETE CASCADE (previously had no ON DELETE action, i.e. deleting a user would fail/be blocked while orphaned rows could exist).

## Key Decisions

- Decision: drop and recreate the same FK constraint name (transactions_user_id_fkey) rather than adding a second constraint.
- Reasoning: confirmed the actual constraint name against the local DB first (implicit names can vary); keeping the same name matches the pattern of every other user-owned table.
- Alternatives considered: none — this mirrors the existing convention exactly.

## How This Affects the System

- User-facing changes: none directly; deleting an auth user (e.g. via account deletion) now also removes their transactions instead of leaving them or failing.
- API changes: none.
- Performance implications: none.
- Database changes: `ALTER TABLE public.transactions ALTER COLUMN user_id SET NOT NULL` + FK re-created with `ON DELETE CASCADE`. Verified zero NULL `user_id` rows exist on both production and staging before writing this migration, so no backfill/deletion step is needed.
- Breaking changes: none for existing data (verified no NULL rows in prod/staging); `types.gen.ts`'s `Insert` type for `transactions` now requires `user_id`, but confirmed no frontend code path passes it explicitly (both insert paths go through RPCs that rely on a trigger to stamp `auth.uid()`).

## Testing

- New tests added: supabase/tests/transactions_rls_test.sql — NOT NULL enforcement (expects SQLSTATE 23502) and cascade-delete verification (deleting the owning auth user removes their transactions).
- Existing tests status: full local pgTAP suite passes (210/210) after this migration.
- Manual testing performed: confirmed via psql that the FK's `confdeltype` is `c` (CASCADE) after migration; ran `tsc --noEmit` and `npm run lint` on apps/web-next — no new errors introduced by this change.
- Edge cases tested: NOT NULL violation in isolation (bypassing RLS to isolate the constraint from the RLS policy check), auth-user-delete cascade.
- Test files modified or added: supabase/tests/transactions_rls_test.sql