### PR TITLE
fix: grant base table privileges to anon/authenticated/service_role locally

### DIFF
--- a/supabase/migrations/20260718212754_fix_local_default_table_grants.sql
+++ b/supabase/migrations/20260718212754_fix_local_default_table_grants.sql
@@ -1,0 +1,10 @@
+-- A fresh local/CI Postgres built only from migrations + seeds ends up with just
+-- TRUNCATE/REFERENCES/TRIGGER granted to anon/authenticated/service_role on public
+-- schema tables. Prod and staging additionally have SELECT/INSERT/UPDATE/DELETE,
+-- granted out-of-band (e.g. via Studio) before the baseline schema was captured, so
+-- this was never recorded in a migration. Without these grants, every query from
+-- those roles fails at the object-privilege level before RLS is even evaluated.
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO anon, authenticated, service_role;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO anon, authenticated, service_role;


### PR DESCRIPTION
## Why

Discovered while implementing S4 (transactions.user_id NOT NULL migration): a fresh local/CI Postgres built purely from supabase/migrations + seeds ends up with only TRUNCATE/REFERENCES/TRIGGER granted to anon/authenticated/service_role on public schema tables — SELECT/INSERT/UPDATE/DELETE are missing. This broke the entire local pgTAP suite (supabase test db) with "permission denied for table X" errors on every single test file, not just new ones, since a query fails at the object-privilege level before RLS is even evaluated.

## What Changed

- Files or areas updated: supabase/migrations/20260718212754_fix_local_default_table_grants.sql
- New functionality added: none
- Existing behavior changed: local/CI Postgres instances built from scratch now get the same base table grants that production/staging already have.

## Key Decisions

- Decision: also add ALTER DEFAULT PRIVILEGES for the public schema, not just a one-time GRANT on existing tables.
- Reasoning: confirmed (via pg_default_acl) that production already has this exact default-privileges rule configured for both the postgres and supabase_admin roles — it was set up by Supabase's own project-provisioning process, which the local CLI's from-scratch migration replay doesn't reproduce. Adding it here keeps any future migration-created table correctly grantable without needing another one-off fix.
- Alternatives considered: only granting on ALL TABLES IN SCHEMA public (no default-privileges rule) — rejected because it would silently regress again the next time a new table is added via migration.

## How This Affects the System

- User-facing changes: none.
- API changes: none.
- Performance implications: none.
- Database changes: GRANT SELECT/INSERT/UPDATE/DELETE on all public schema tables + a matching ALTER DEFAULT PRIVILEGES rule, for anon/authenticated/service_role.
- Breaking changes: none. Verified directly against production and staging (via pg_default_acl / information_schema.role_table_grants) that both statements are no-ops there — prod/staging already have these exact grants and default-privileges rule from prior out-of-band setup, so this migration only changes behavior for fresh local/CI databases.

## Testing

- New tests added: none (this is a permissions fix, not app logic).
- Existing tests status: full local pgTAP suite (supabase test db) now passes 208/208 on a fresh supabase db reset with no manual workaround, versus failing across every test file beforehand.
- Manual testing performed: confirmed via information_schema.role_table_grants that anon/authenticated/service_role have SELECT/INSERT/UPDATE/DELETE after the migration; regenerated types.gen.ts and diffed — no changes (grants-only, no schema change).
- Edge cases tested: verified idempotency against production/staging state directly (read-only queries) before concluding this is safe to ship.
- Test files modified or added: none