### PR TITLE
fix: add security headers to vercel.json

### DIFF
--- a/apps/web-next/vercel.json
+++ b/apps/web-next/vercel.json
@@ -1,3 +1,15 @@
 {
-  "ignoreCommand": "git diff HEAD^ HEAD --quiet -- ."
+  "ignoreCommand": "git diff HEAD^ HEAD --quiet -- .",
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" },
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' https://*.supabase.co wss://*.supabase.co; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" }
+      ]
+    }
+  ]
 }

--- a/docs/superpowers/plans/2026-07-18-security-review-fixes.md
+++ b/docs/superpowers/plans/2026-07-18-security-review-fixes.md
@@ -133,7 +133,7 @@ ALTER TABLE public.transactions
 
 ## Worth-doing items
 
-### Security headers — `apps/web-next/vercel.json`
+### ✅ Done — Security headers — `apps/web-next/vercel.json`
 
 Current file (entire contents):
 ```json


### PR DESCRIPTION
## Why

The 2026-07-18 security review (docs/superpowers/plans/2026-07-18-security-review-fixes.md)
flagged that apps/web-next/vercel.json had no security headers configured — only an
`ignoreCommand` key. This is a Vite SPA, not Next.js, so headers must be set explicitly
via vercel.json rather than framework defaults.

## What Changed

- Files or areas updated: `apps/web-next/vercel.json`
- New functionality added: a `headers` block applying to all routes (`/(.*)`):
  - `X-Frame-Options: DENY`
  - `X-Content-Type-Options: nosniff`
  - `Referrer-Policy: strict-origin-when-cross-origin`
  - `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload`
  - `Content-Security-Policy` scoped to self + `https://*.supabase.co` / `wss://*.supabase.co`
- Existing behavior changed: none functionally; adds response headers only.

## Key Decisions

- Decision: `style-src` includes `'unsafe-inline'`.
- Reasoning: Ant Design v5's CSS-in-JS (`@ant-design/cssinjs`) injects `<style>` tags at
  runtime with no nonce, and `App.tsx` has no `StyleProvider`/nonce config. Tightening this
  further would require a separate antd nonce-support change — out of scope here.
- Alternatives considered: wildcarding the Supabase domain more broadly, rejected in favor
  of scoping to `*.supabase.co` since the real project domain isn't in the repo (only
  injected via Vercel env vars at deploy time).

## How This Affects the System

- User-facing changes: none visible; adds security headers to all responses.
- API changes: none.
- Performance implications: none.
- Database changes: none.
- Breaking changes: none expected, but see Testing — CSP failures are silent (styling
  glitches, blocked XHR) rather than loud errors.

## Testing

- New tests added: none (config-only change, not testable locally).
- Existing tests status: unaffected.
- Manual testing performed: validated `vercel.json` is syntactically valid JSON. Vercel
  headers only apply at Vercel's edge, so this **cannot be verified from local `vite dev`**.
- Edge cases tested: n/a locally.
- Test files modified or added: none.

**Post-deploy follow-up required:** once deployed to a preview/staging build, run `curl -I`
against it and confirm the CSP doesn't break antd styling, Supabase auth (login flow), or
realtime — see the plan doc's verification section.