### PR TITLE
fix: sanitize raw SQLERRM in bulk-upload RPCs

### DIFF
--- a/docs/api/bulk-upload.md
+++ b/docs/api/bulk-upload.md
@@ -62,9 +62,13 @@ interface CategoryInput {
 - `description`: Optional, max 1000 characters
 
 **Validation:**
-- Both `type` and `name` are required
-- Missing required fields raises exception: `"Missing required field: type"` or `"Missing required field: name"`
-- Invalid enum value raises exception: `"Invalid transaction_type value"`
+- Both `type` and `name` are required for every element in the array
+- If any element is missing `name` or `type`, the **whole batch** is rejected with:
+  `insert_categories: one or more items are missing required fields "name" or "type"`
+- If any element has an invalid `type`, the whole batch is rejected with:
+  `insert_categories: invalid transaction_type: <value>`
+- These are validation errors (SQLSTATE `P0001`) and are surfaced to the client with this exact
+  message — see [Error Response](#error-response) below.
 
 ### Bank Account Input Schema
 
@@ -82,8 +86,9 @@ interface BankAccountInput {
 - `description`: Optional, max 1000 characters
 
 **Validation:**
-- `name` is required
-- Missing name raises exception: `"Missing required field: name"`
+- `name` is required for every element in the array
+- If any element is missing `name`, the **whole batch** is rejected with:
+  `insert_bank_accounts: one or more items are missing required field "name"` (SQLSTATE `P0001`)
 
 ### Tag Input Schema
 
@@ -101,8 +106,9 @@ interface TagInput {
 - `description`: Optional, max 1000 characters
 
 **Validation:**
-- `name` is required
-- Missing name raises exception: `"Missing required field: name"`
+- `name` is required for every element in the array
+- If any element is missing `name`, the **whole batch** is rejected with:
+  `insert_tags: one or more items are missing required field "name"` (SQLSTATE `P0001`)
 
 ### Transaction Input Schema
 
@@ -119,18 +125,28 @@ interface TransactionInput {
 ```
 
 **Constraints:**
-- `date`: ISO 8601 format `YYYY-MM-DD`
+- `date`: Cast directly to a Postgres `date` — use `YYYY-MM-DD` to avoid ambiguity. There's no
+  explicit format check; a malformed value surfaces as a sanitized per-row error (see below),
+  not a descriptive format message.
 - `type`: Must be `earn`, `spend`, or `save`
-- `amount`: Positive number
-- `category`: Must reference existing category or one in same upload
-- `bank_account`: Must reference existing bank account or one in same upload
-- `tags`: Array of strings, each must reference existing tag or one in same upload
+- `amount`: Numeric. There's no positivity check today — zero/negative values are accepted.
+- `category`: Must reference an existing **leaf** category (no sub-categories) of matching
+  `type` for the authenticated user, or one included in the same `categories` section
+- `bank_account`: Must reference an existing bank account for the authenticated user, or one
+  included in the same `bank_accounts` section
+- `tags`: Array of strings, each must reference an existing tag for the authenticated user, or
+  one included in the same `tags` section
 
-**Validation:**
-- `date`, `type`, and `amount` are required
-- Date format validation: Must match `YYYY-MM-DD` pattern
-- Amount validation: Must be > 0
-- Category/bank_account/tags validation: Must exist in user's data or upload
+**Validation (per row, 1-indexed, collected into `error.details` — see
+[Error Response](#error-response)):**
+- `date`, `type`, and `amount` presence: `Missing required field: <field>` or
+  `Missing required fields: <a>, <b>`
+- Invalid `type` value: `Invalid transaction type: "<value>"`
+- Category not found as a leaf for the row's type: `Category "<name>" not found as leaf for type "<type>"`
+- Bank account not found: `Bank account "<name>" not found`
+- Tag not found: `Tag "<name>" not found`
+- Any other unexpected DB error for the row (e.g. a malformed `date`) is sanitized rather than
+  passed through raw — see [Error Response](#error-response)
 
 ## Return Value
 
@@ -157,35 +173,46 @@ interface TransactionInput {
 
 ### Error Response
 
-On any validation error, the entire operation is rolled back (atomicity guaranteed).
+On any error, the entire operation is rolled back (atomicity guaranteed). Errors are **not**
+returned inside the JSONB return value — there is no `{success: false, ...}` shape. Instead the
+function raises a Postgres exception, so supabase-js resolves the call with `data: null` and a
+populated `error` (a `PostgrestError`):
 
-```json
-{
-  "success": false,
-  "error": "Invalid transaction_type value: invalid",
-  "details": {
-    "categories": null,
-    "bank_accounts": null,
-    "tags": null,
-    "transactions": [
-      {
-        "row": 1,
-        "field": "type",
-        "error": "Invalid transaction_type value: invalid"
-      }
-    ]
-  }
-}
+```typescript
+const { data, error } = await supabase.rpc('bulk_upload_data', { p_payload: payload });
+// on failure: data === null
+// error.message — see below
+// error.details — a JSON string, only populated for per-row transaction errors
+// error.code    — the Postgres SQLSTATE
 ```
 
-**Fields:**
-- `success`: Boolean, always `false` on error
-- `error`: High-level error message
-- `details` (optional): Detailed error information by section
-  - Each section contains array of errors with:
-    - `row`: 1-indexed row number (if applicable)
-    - `field`: Field name that caused error
-    - `error`: Descriptive error message
+**Validation errors** (missing required fields, invalid enum values, "not found" lookups) are
+raised with SQLSTATE `P0001` and pass through to the client with their exact message unchanged
+— see the per-section validation messages above. These are safe, intentional, user-facing
+strings.
+
+**Per-row transaction errors**: `bulk_insert_transactions` validates each transaction
+independently and, if any fail, raises a single exception for the whole call:
+- `error.message`: `"Bulk insert failed with N error(s)"`
+- `error.details`: a JSON **string** — call `JSON.parse(error.details)` to get an array of
+  `{ index, error, sqlstate? }`, one entry per failed row (`index` is 1-indexed). `sqlstate` is
+  present only when the row failed on an unexpected DB error rather than app-level validation.
+
+**Unexpected/internal errors**: any DB error not covered by the validation above (e.g. a
+constraint the app doesn't explicitly check for) is sanitized to a fixed message instead of the
+raw Postgres error text, so internals like constraint names are never leaked to the client:
+- For a failed transaction row, that row's `error` field in `error.details` becomes one of
+  `"Duplicate entry"`, `"Referenced record not found"`, `"Value violates a constraint"`, or
+  `"Row could not be inserted"` (fallback) — the real SQLSTATE is still in that row's `sqlstate`
+  field.
+- For anything else (the categories/bank_accounts/tags helpers, or `bulk_upload_data` itself),
+  `error.message` becomes a fixed string: `"insert_categories failed"`,
+  `"insert_bank_accounts failed"`, `"insert_tags failed"`, or `"bulk_upload_data failed"`. The
+  original SQLSTATE is preserved on `error.code`, but no free-text detail is exposed.
+- This also applies to auth failures: if `auth.uid()` is null inside `bulk_upload_data` itself,
+  the client does **not** see `"Not authenticated"` verbatim — it's folded into the generic
+  `"bulk_upload_data failed"` message with `error.code === '42501'`. Check `error.code` rather
+  than matching on `error.message` to detect this case.
 
 ## Examples
 
@@ -356,21 +383,12 @@ const { data, error } = await supabase.rpc('bulk_upload_data', {
 });
 ```
 
-**Response:**
-```json
-{
-  "success": false,
-  "error": "Invalid transaction_type value",
-  "details": {
-    "categories": [
-      {
-        "row": 1,
-        "field": "type",
-        "error": "Invalid transaction_type value: invalid"
-      }
-    ]
-  }
-}
+**Result:**
+```typescript
+data === null;
+error.message === 'insert_categories: invalid transaction_type: invalid';
+error.code === 'P0001';
+error.details === null;
 ```
 
 ### Example 6: Validation Error (Missing Required Field)
@@ -390,64 +408,101 @@ const { data, error } = await supabase.rpc('bulk_upload_data', {
 });
 ```
 
-**Response:**
-```json
-{
-  "success": false,
-  "error": "Missing required field: name",
-  "details": {
-    "categories": [
-      {
-        "row": 1,
-        "field": "name",
-        "error": "Missing required field: name"
-      }
-    ]
-  }
-}
+**Result:**
+```typescript
+data === null;
+error.message === 'insert_categories: one or more items are missing required fields "name" or "type"';
+error.code === 'P0001';
+error.details === null;
 ```
+
+### Example 7: Per-Row Transaction Validation Error
+
+**Request:**
+```typescript
+const payload = {
+  transactions: [
+    { type: "spend", amount: 45.67 } // missing `date`
+  ]
+};
+
+const { data, error } = await supabase.rpc('bulk_upload_data', {
+  p_payload: payload
+});
+```
+
+**Result:**
+```typescript
+data === null;
+error.message === 'Bulk insert failed with 1 error(s)';
+error.code === 'P0001';
+
+const rows = JSON.parse(error.details);
+// rows === [{ index: 1, error: 'Missing required field: date' }]
+```
+
+### Example 8: Sanitized Unexpected Error
+
+An unexpected DB error (anything not covered by the app's explicit validation) never surfaces
+raw Postgres text. For a failed transaction row this looks like:
+
+```typescript
+const rows = JSON.parse(error.details);
+// rows === [{ index: 3, error: 'Value violates a constraint', sqlstate: '23514' }]
+```
+
+For everything else, `error.message` is a fixed string (e.g. `'insert_categories failed'`) with
+the real SQLSTATE preserved on `error.code`.
 
 ## Error Codes & Messages
 
+`error.code` is the Postgres SQLSTATE. `P0001` is what Postgres assigns to a plain
+`RAISE EXCEPTION` with no explicit `ERRCODE` — that's what every validation message below uses,
+but generic/sanitized errors can also carry `P0001` in other parts of the schema, so match on
+the message text (or `error.details` for per-row transaction errors), not on `error.code` alone,
+except where noted.
+
 ### Authentication Errors
 
-| Error | Cause | Solution |
+| Code | Message | Cause |
 |---|---|---|
-| "Not authenticated" | `auth.uid()` returns NULL | Ensure user is logged in |
+| `42501` | `"bulk_upload_data failed"` | `auth.uid()` returned NULL. The underlying `"Not authenticated"` text is not exposed to the client — detect this case via `error.code`, not the message. |
 
-### Category Errors
+### Category Errors (whole batch, not per-row)
 
-| Error | Cause | Solution |
+| Code | Message | Cause |
 |---|---|---|
-| "Invalid transaction_type value: X" | Invalid category type | Use only: `earn`, `spend`, `save` |
-| "Missing required field: type" | Category type not provided | Add `type` field |
-| "Missing required field: name" | Category name not provided | Add `name` field |
+| `P0001` | `insert_categories: one or more items are missing required fields "name" or "type"` | Any element in `categories` is missing `name` and/or `type` |
+| `P0001` | `insert_categories: invalid transaction_type: <value>` | Any element's `type` isn't `earn`/`spend`/`save` |
+| *original code* | `"insert_categories failed"` | Any other DB error — sanitized; original SQLSTATE preserved on `error.code` |
 
-### Bank Account Errors
+### Bank Account Errors (whole batch, not per-row)
 
-| Error | Cause | Solution |
+| Code | Message | Cause |
 |---|---|---|
-| "Missing required field: name" | Account name not provided | Add `name` field |
+| `P0001` | `insert_bank_accounts: one or more items are missing required field "name"` | Any element in `bank_accounts` is missing `name` |
+| *original code* | `"insert_bank_accounts failed"` | Any other DB error — sanitized |
 
-### Tag Errors
+### Tag Errors (whole batch, not per-row)
 
-| Error | Cause | Solution |
+| Code | Message | Cause |
 |---|---|---|
-| "Missing required field: name" | Tag name not provided | Add `name` field |
+| `P0001` | `insert_tags: one or more items are missing required field "name"` | Any element in `tags` is missing `name` |
+| *original code* | `"insert_tags failed"` | Any other DB error — sanitized |
 
-### Transaction Errors
+### Transaction Errors (per row — read from `JSON.parse(error.details)`)
 
-| Error | Cause | Solution |
+| `error` value | `sqlstate` present? | Cause |
 |---|---|---|
-| "Invalid transaction_type value: X" | Invalid transaction type | Use only: `earn`, `spend`, `save` |
-| "Missing required field: date" | Transaction date not provided | Add `date` field in YYYY-MM-DD format |
-| "Missing required field: type" | Transaction type not provided | Add `type` field |
-| "Missing required field: amount" | Transaction amount not provided | Add `amount` field |
-| "Invalid date format" | Date not in YYYY-MM-DD | Use ISO 8601 format |
-| "Amount must be positive" | Amount is zero or negative | Use positive numbers only |
-| "Category 'X' not found" | Referenced category doesn't exist | Add to categories section or create manually |
-| "Bank account 'X' not found" | Referenced account doesn't exist | Add to bank_accounts section or create manually |
-| "Tag 'X' not found" | Referenced tag doesn't exist | Add to tags section or create manually |
+| `Missing required field: <field>` / `Missing required fields: <a>, <b>` | no | Row is missing `date`, `type`, and/or `amount` |
+| `Invalid transaction type: "<value>"` | no | Row's `type` isn't `earn`/`spend`/`save` |
+| `Category "<name>" not found as leaf for type "<type>"` | no | No matching leaf category for that user/type/name |
+| `Bank account "<name>" not found` | no | No matching bank account for that user/name |
+| `Tag "<name>" not found` | no | No matching tag for that user/name |
+| `Duplicate entry` | yes (`23505`) | Sanitized — an unhandled uniqueness conflict |
+| `Referenced record not found` | yes (`23503`) | Sanitized — an unhandled foreign-key violation |
+| `Value violates a constraint` | yes (`23514`) | Sanitized — e.g. the transaction's `type` doesn't match its category's `type` |
+| `Row could not be inserted` | yes (other) | Sanitized fallback for any other unexpected error, e.g. a malformed `date` |
 
 ## Security Considerations
 
@@ -599,4 +654,4 @@ A: This function only imports. Export functionality is not yet available.
 
 ---
 
-**Last Updated**: November 9, 2025
+**Last Updated**: July 19, 2026

--- a/docs/superpowers/plans/2026-07-18-security-review-fixes.md
+++ b/docs/superpowers/plans/2026-07-18-security-review-fixes.md
@@ -183,7 +183,7 @@ deleteMany: async ({ resource, ids, meta }) => {
 },
 ```
 
-### RPC error sanitization — bulk upload
+### ✅ Done — RPC error sanitization — bulk upload
 
 DB side, `supabase/migrations/20260201164000_baseline_from_schemas.sql`, four spots currently surface raw `SQLERRM` (a live Postgres error string, e.g. constraint names) straight to the client:
 - `bulk_insert_transactions` (line 1485) — per-row `'error', SQLERRM` collected into `v_errors`, then raised via `USING DETAIL = v_errors::text` (line 1495-1496)

--- a/supabase/migrations/20260719162135_sanitize_bulk_upload_errors.sql
+++ b/supabase/migrations/20260719162135_sanitize_bulk_upload_errors.sql
@@ -1,0 +1,446 @@
+-- Stop leaking raw Postgres error text (SQLERRM) to bulk-upload clients.
+-- Replace it with a SQLSTATE-classified friendly message; the original
+-- SQLSTATE is preserved via ERRCODE so it's still available for support/
+-- debugging through PostgREST's error code field, without exposing
+-- internals like constraint names.
+
+-- bulk_insert_transactions: per-row errors, classify SQLERRM by SQLSTATE
+CREATE OR REPLACE FUNCTION public.bulk_insert_transactions(p_transactions jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_user_id        uuid;
+  v_tx             jsonb;
+  v_category_id    uuid;
+  v_bank_account_id uuid;
+  v_tx_id          uuid;
+  v_inserted_count integer := 0;
+  v_errors         jsonb   := '[]'::jsonb;
+  v_idx            integer := 0;
+  v_type           public.transaction_type;
+  v_tag            text;
+  v_tag_exists     boolean;
+BEGIN
+  -- Authenticate
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated' USING ERRCODE = '42501';
+  END IF;
+
+  -- Ensure input is an array
+  IF p_transactions IS NULL OR jsonb_typeof(p_transactions) <> 'array' THEN
+    RAISE EXCEPTION 'p_transactions must be a JSON array' USING ERRCODE = '22023';
+  END IF;
+
+  -- Iterate through each element
+  FOR v_tx IN SELECT * FROM jsonb_array_elements(p_transactions)
+  LOOP
+    v_idx := v_idx + 1;
+
+    BEGIN
+      -- Required fields
+      DECLARE
+        v_missing_fields text[] := ARRAY[]::text[];
+        v_error_msg      text;
+      BEGIN
+        IF v_tx->>'date' IS NULL THEN
+          v_missing_fields := array_append(v_missing_fields, 'date');
+        END IF;
+        IF v_tx->>'type' IS NULL THEN
+          v_missing_fields := array_append(v_missing_fields, 'type');
+        END IF;
+        IF v_tx->>'amount' IS NULL THEN
+          v_missing_fields := array_append(v_missing_fields, 'amount');
+        END IF;
+        IF array_length(v_missing_fields, 1) IS NOT NULL THEN
+          IF array_length(v_missing_fields, 1) = 1 THEN
+            v_error_msg := format('Missing required field: %s', v_missing_fields[1]);
+          ELSE
+            v_error_msg := format('Missing required fields: %s', array_to_string(v_missing_fields, ', '));
+          END IF;
+          v_errors := v_errors || jsonb_build_object(
+            'index', v_idx,
+            'error', v_error_msg
+          );
+          CONTINUE;
+        END IF;
+      END;
+
+      -- Type validation (casts to enum)
+      BEGIN
+        v_type := (v_tx->>'type')::public.transaction_type;
+      EXCEPTION WHEN OTHERS THEN
+        v_errors := v_errors || jsonb_build_object(
+          'index', v_idx,
+          'error', format('Invalid transaction type: "%s"', v_tx->>'type')
+        );
+        CONTINUE;
+      END;
+
+      -- Resolve category name -> id (leaf categories only)
+      v_category_id := NULL;
+      IF v_tx->>'category' IS NOT NULL THEN
+        SELECT c.id INTO v_category_id
+        FROM public.categories c
+        LEFT JOIN public.category_hierarchy ch
+          ON ch.ancestor_id = c.id AND ch.depth = 1
+        WHERE c.user_id = v_user_id
+          AND c.type    = v_type
+          AND c.name    = v_tx->>'category'
+        GROUP BY c.id
+        HAVING COUNT(ch.descendant_id) = 0
+        LIMIT 1;
+
+        IF v_category_id IS NULL THEN
+          v_errors := v_errors || jsonb_build_object(
+            'index', v_idx,
+            'error', format('Category "%s" not found as leaf for type "%s"', v_tx->>'category', v_type)
+          );
+          CONTINUE;
+        END IF;
+      END IF;
+
+      -- Resolve bank account name -> id if provided
+      v_bank_account_id := NULL;
+      IF v_tx->>'bank_account' IS NOT NULL THEN
+        SELECT id INTO v_bank_account_id
+        FROM public.bank_accounts
+        WHERE user_id = v_user_id
+          AND name = v_tx->>'bank_account'
+        LIMIT 1;
+
+        IF v_bank_account_id IS NULL THEN
+          v_errors := v_errors || jsonb_build_object(
+            'index', v_idx,
+            'error', format('Bank account "%s" not found', v_tx->>'bank_account')
+          );
+          CONTINUE;
+        END IF;
+      END IF;
+
+      -- Validate tags exist (if provided)
+      IF v_tx->'tags' IS NOT NULL THEN
+        FOR v_tag IN SELECT jsonb_array_elements_text(v_tx->'tags')
+        LOOP
+          SELECT EXISTS(
+            SELECT 1 FROM public.tags WHERE user_id = v_user_id AND name = v_tag
+          ) INTO v_tag_exists;
+
+          IF NOT v_tag_exists THEN
+            v_errors := v_errors || jsonb_build_object(
+              'index', v_idx,
+              'error', format('Tag "%s" not found', v_tag)
+            );
+            EXIT;
+          END IF;
+        END LOOP;
+
+        IF jsonb_array_length(v_errors) > 0 AND (v_errors->-1->>'index')::integer = v_idx THEN
+          CONTINUE;
+        END IF;
+      END IF;
+
+      -- Insert transaction
+      INSERT INTO public.transactions (
+        user_id,
+        date,
+        type,
+        category_id,
+        bank_account_id,
+        amount,
+        tags,
+        notes
+      ) VALUES (
+        v_user_id,
+        (v_tx->>'date')::date,
+        v_type,
+        v_category_id,
+        v_bank_account_id,
+        (v_tx->>'amount')::numeric,
+        CASE WHEN v_tx->'tags' IS NOT NULL
+          THEN (SELECT array_agg(value::text) FROM jsonb_array_elements_text(v_tx->'tags'))
+          ELSE NULL END,
+        v_tx->>'notes'
+      )
+      RETURNING id INTO v_tx_id;
+
+      v_inserted_count := v_inserted_count + 1;
+
+      -- Insert tag associations into transaction_tags
+      IF v_tx->'tags' IS NOT NULL THEN
+        INSERT INTO public.transaction_tags (transaction_id, tag_id)
+        SELECT DISTINCT
+          v_tx_id,
+          tg.id
+        FROM jsonb_array_elements_text(v_tx->'tags') AS jt(tag_name)
+        JOIN public.tags tg ON tg.user_id = v_user_id AND tg.name = jt.tag_name
+        ON CONFLICT (transaction_id, tag_id) DO NOTHING;
+      END IF;
+
+    EXCEPTION WHEN OTHERS THEN
+      v_errors := v_errors || jsonb_build_object(
+        'index', v_idx,
+        'error', CASE SQLSTATE
+          WHEN '23505' THEN 'Duplicate entry'
+          WHEN '23503' THEN 'Referenced record not found'
+          WHEN '23514' THEN 'Value violates a constraint'
+          ELSE 'Row could not be inserted'
+        END,
+        'sqlstate', SQLSTATE
+      );
+    END;
+
+  END LOOP;
+
+  IF jsonb_array_length(v_errors) > 0 THEN
+    RAISE EXCEPTION 'Bulk insert failed with % error(s)', jsonb_array_length(v_errors)
+      USING DETAIL = v_errors::text;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'inserted_count', v_inserted_count,
+    'total_count', v_idx
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.bulk_insert_transactions IS
+  'Atomically insert multiple transactions from JSON. Validates foreign keys, rolls back on any error. Only leaf categories (no children) are accepted.';
+
+-- insert_categories: drop raw SQLERRM from the catch-all, keep SQLSTATE via ERRCODE
+CREATE OR REPLACE FUNCTION insert_categories (p_user_id UUID, p_categories jsonb) RETURNS INT LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = '' AS $$
+DECLARE
+  v_missing_count int;
+  v_invalid_type text;
+  v_inserted_count int := 0;
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'insert_categories: not authenticated' USING ERRCODE = '42501';
+  END IF;
+
+  IF auth.uid()::text <> p_user_id::text THEN
+    RAISE EXCEPTION 'insert_categories: not authorized to insert for this user' USING ERRCODE = '42501';
+  END IF;
+
+  IF p_categories IS NULL OR jsonb_array_length(p_categories) = 0 THEN
+    RETURN 0;
+  END IF;
+
+  SELECT COUNT(*) INTO v_missing_count
+  FROM jsonb_array_elements(p_categories) AS elem
+  WHERE (elem->>'name') IS NULL OR (elem->>'type') IS NULL;
+
+  IF v_missing_count > 0 THEN
+    RAISE EXCEPTION 'insert_categories: one or more items are missing required fields "name" or "type"';
+  END IF;
+
+  WITH types AS (
+    SELECT DISTINCT (elem->>'type') AS typ
+    FROM jsonb_array_elements(p_categories) AS elem
+  ), invalid AS (
+    SELECT typ
+    FROM types
+    WHERE typ NOT IN (
+      SELECT enumlabel
+      FROM pg_enum
+      WHERE enumtypid = 'public.transaction_type'::regtype
+    )
+  )
+  SELECT typ INTO v_invalid_type FROM invalid LIMIT 1;
+
+  IF v_invalid_type IS NOT NULL THEN
+    RAISE EXCEPTION 'insert_categories: invalid transaction_type: %', v_invalid_type;
+  END IF;
+
+  INSERT INTO public.categories (user_id, type, name, description)
+  SELECT
+    p_user_id,
+    (elem->>'type')::public.transaction_type,
+    elem->>'name',
+    elem->>'description'
+  FROM jsonb_array_elements(p_categories) AS elem
+  ON CONFLICT ON CONSTRAINT unique_user_type_name DO NOTHING;
+
+  GET DIAGNOSTICS v_inserted_count = ROW_COUNT;
+
+  RETURN v_inserted_count;
+EXCEPTION
+  WHEN SQLSTATE 'P0001' THEN
+    RAISE;
+  WHEN others THEN
+    RAISE EXCEPTION 'insert_categories failed' USING ERRCODE = SQLSTATE;
+END;
+$$;
+
+-- insert_bank_accounts: drop raw SQLERRM from the catch-all, keep SQLSTATE via ERRCODE
+CREATE
+OR REPLACE FUNCTION insert_bank_accounts (p_user_id UUID, p_bank_accounts jsonb) RETURNS INT LANGUAGE plpgsql SECURITY DEFINER
+SET
+  search_path = '' AS $$
+DECLARE
+  v_missing_count int;
+  v_inserted_count int := 0;
+BEGIN
+  -- Authorization
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'insert_bank_accounts: not authenticated' USING ERRCODE = '42501';
+  END IF;
+
+  IF auth.uid()::text <> p_user_id::text THEN
+    RAISE EXCEPTION 'insert_bank_accounts: not authorized to insert for this user' USING ERRCODE = '42501';
+  END IF;
+
+  -- Nothing to do for NULL or empty input
+  IF p_bank_accounts IS NULL OR jsonb_array_length(p_bank_accounts) = 0 THEN
+    RETURN 0;
+  END IF;
+
+  -- Validate required field: name must be present for every element
+  SELECT COUNT(*) INTO v_missing_count
+  FROM jsonb_array_elements(p_bank_accounts) AS elem
+  WHERE (elem->>'name') IS NULL;
+
+  IF v_missing_count > 0 THEN
+    RAISE EXCEPTION 'insert_bank_accounts: one or more items are missing required field "name"';
+  END IF;
+
+  -- Batch insert using JSONB array elements. Use explicit p_user_id and
+  -- ON CONFLICT DO NOTHING to avoid duplicates.
+  INSERT INTO public.bank_accounts (user_id, name, description)
+  SELECT
+    p_user_id,
+    elem->>'name',
+    elem->>'description'
+  FROM jsonb_array_elements(p_bank_accounts) AS elem
+  ON CONFLICT (user_id, name) DO NOTHING;
+
+  -- Get the number of rows actually inserted
+  GET DIAGNOSTICS v_inserted_count = ROW_COUNT;
+
+  RETURN v_inserted_count;
+EXCEPTION
+  WHEN SQLSTATE 'P0001' THEN
+    RAISE;
+  WHEN others THEN
+    RAISE EXCEPTION 'insert_bank_accounts failed' USING ERRCODE = SQLSTATE;
+END;
+$$;
+
+-- insert_tags: drop raw SQLERRM from the catch-all, keep SQLSTATE via ERRCODE
+CREATE
+OR REPLACE FUNCTION insert_tags (p_user_id UUID, p_tags jsonb) RETURNS INT LANGUAGE plpgsql SECURITY DEFINER
+SET
+  search_path = '' AS $$
+DECLARE
+  v_missing_count int;
+  v_inserted_count int := 0;
+BEGIN
+  -- Authorization
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'insert_tags: not authenticated' USING ERRCODE = '42501';
+  END IF;
+
+  IF auth.uid()::text <> p_user_id::text THEN
+    RAISE EXCEPTION 'insert_tags: not authorized to insert for this user' USING ERRCODE = '42501';
+  END IF;
+
+  -- Nothing to do for NULL or empty input
+  IF p_tags IS NULL OR jsonb_array_length(p_tags) = 0 THEN
+    RETURN 0;
+  END IF;
+
+  -- Validate required field: name must be present for every element
+  SELECT COUNT(*) INTO v_missing_count
+  FROM jsonb_array_elements(p_tags) AS elem
+  WHERE (elem->>'name') IS NULL;
+
+  IF v_missing_count > 0 THEN
+    RAISE EXCEPTION 'insert_tags: one or more items are missing required field "name"';
+  END IF;
+
+  -- Batch insert using JSONB array elements. Use explicit p_user_id and
+  -- ON CONFLICT DO NOTHING to avoid duplicates.
+  INSERT INTO public.tags (user_id, name, description)
+  SELECT
+    p_user_id,
+    elem->>'name',
+    elem->>'description'
+  FROM jsonb_array_elements(p_tags) AS elem
+  ON CONFLICT (user_id, name) DO NOTHING;
+
+  -- Get the number of rows actually inserted
+  GET DIAGNOSTICS v_inserted_count = ROW_COUNT;
+
+  RETURN v_inserted_count;
+EXCEPTION
+  WHEN SQLSTATE 'P0001' THEN
+    RAISE;
+  WHEN others THEN
+    RAISE EXCEPTION 'insert_tags failed' USING ERRCODE = SQLSTATE;
+END;
+$$;
+
+-- bulk_upload_data: drop raw SQLERRM from the catch-all, keep SQLSTATE via ERRCODE
+CREATE
+OR REPLACE FUNCTION public.bulk_upload_data (p_payload jsonb) RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+SET
+  search_path = '' AS $$
+DECLARE
+  v_user_id uuid;
+  v_categories_inserted int := 0;
+  v_bank_accounts_inserted int := 0;
+  v_tags_inserted int := 0;
+  v_transactions_inserted int := 0;
+  v_tx_result jsonb;
+BEGIN
+  -- Authenticate caller
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'bulk_upload_data: not authenticated' USING ERRCODE = '42501';
+  END IF;
+
+  -- Categories (if provided)
+  IF p_payload ? 'categories' AND p_payload->'categories' IS NOT NULL THEN
+    v_categories_inserted := public.insert_categories(v_user_id, p_payload->'categories');
+  END IF;
+
+  -- Bank accounts (if provided)
+  IF p_payload ? 'bank_accounts' AND p_payload->'bank_accounts' IS NOT NULL THEN
+    v_bank_accounts_inserted := public.insert_bank_accounts(v_user_id, p_payload->'bank_accounts');
+  END IF;
+
+  -- Tags (if provided)
+  IF p_payload ? 'tags' AND p_payload->'tags' IS NOT NULL THEN
+    v_tags_inserted := public.insert_tags(v_user_id, p_payload->'tags');
+  END IF;
+
+  -- Transactions (if provided) - delegate to existing bulk_insert_transactions
+  IF p_payload ? 'transactions' AND p_payload->'transactions' IS NOT NULL THEN
+    -- bulk_insert_transactions is SECURITY DEFINER and will itself authenticate using auth.uid()
+    v_tx_result := public.bulk_insert_transactions(p_payload->'transactions');
+    -- Extract inserted_count if present
+    IF v_tx_result IS NOT NULL AND v_tx_result ? 'inserted_count' THEN
+      v_transactions_inserted := (v_tx_result->>'inserted_count')::int;
+    END IF;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'categories_inserted', v_categories_inserted,
+    'bank_accounts_inserted', v_bank_accounts_inserted,
+    'tags_inserted', v_tags_inserted,
+    'transactions_inserted', v_transactions_inserted
+  );
+EXCEPTION
+  WHEN SQLSTATE 'P0001' THEN
+    -- validation exceptions raised by helpers - preserve them
+    RAISE;
+  WHEN others THEN
+    RAISE EXCEPTION 'bulk_upload_data failed' USING ERRCODE = SQLSTATE;
+END;
+$$;


### PR DESCRIPTION
## Why

The 2026-07-18 security review (docs/superpowers/plans/2026-07-18-security-review-fixes.md)
flagged that several bulk-upload RPCs surfaced raw Postgres error text (`SQLERRM`) straight
to clients on unexpected failures — potentially leaking internals like constraint names.
The client (`apps/web-next/src/pages/settings/index.tsx`) renders these messages directly
in a notification with no sanitization layer.

## What Changed

- Files or areas updated: new migration
  `supabase/migrations/20260719162135_sanitize_bulk_upload_errors.sql`, replacing five
  functions via `CREATE OR REPLACE`:
  - `bulk_insert_transactions` — per-row catch-all now classifies the error by `SQLSTATE`
    into a friendly message (`Duplicate entry`, `Referenced record not found`, `Value
    violates a constraint`, or a generic fallback), keeping `sqlstate` in the row payload.
  - `insert_categories`, `insert_bank_accounts`, `insert_tags`, `bulk_upload_data` — each
    catch-all (`WHEN others`) now raises a fixed generic message instead of interpolating
    `SQLERRM`, while preserving the original `SQLSTATE` via `USING ERRCODE = SQLSTATE` so
    it's still available through PostgREST's error code field for support/debugging.
- New functionality added: none — this only changes what unexpected-error paths reveal.
- Existing behavior changed: intentional validation errors (`SQLSTATE 'P0001'`, e.g. "missing
  required field", "invalid transaction_type") are untouched and still re-raised as-is —
  those are authored user-facing messages, not raw Postgres internals.

Note: two of the five functions (`bulk_insert_transactions`, `insert_categories`) had
already been redefined by later migrations
(`20260601220000_bulk_insert_leaf_categories.sql`,
`20260627124710_fix_category_unique_constraint_include_parent_id.sql`) since the original
security review was written, so this migration replaces their *current* bodies, not the
stale baseline-file versions the review doc quoted.

## Key Decisions

- Decision: preserve `SQLSTATE` via `ERRCODE` on the re-raised generic exception rather than
  dropping it entirely.
- Reasoning: keeps the error code available for support/debugging via PostgREST without
  exposing the free-text Postgres internals (e.g. constraint names) that motivated this fix.
- Alternatives considered: returning a structured `{error, sqlstate}` object from all five
  functions (matching `bulk_insert_transactions`'s existing shape) — deferred, since the four
  single-item RPCs (`insert_categories` etc.) raise via `RAISE EXCEPTION` rather than
  returning a result object, and changing that return contract is a bigger, unrelated change.

## How This Affects the System

- User-facing changes: on an unexpected DB error during bulk upload, users now see a generic
  message instead of raw Postgres text. Intentional validation messages are unchanged.
- API changes: none (same RPC signatures).
- Performance implications: none.
- Database changes: replaces 5 function bodies via `CREATE OR REPLACE`, no schema/table
  changes.
- Breaking changes: none expected. `docs/api/bulk-upload.md` already documented a different
  error shape than what the SQL actually returns — pre-existing doc debt, not touched here
  (flagged separately in the plan doc).

## Testing

- New tests added: none — existing pgTAP coverage
  (`bulk_insert_test.sql`, `bulk_upload_entities_test.sql`) already exercises these RPCs'
  success and validation-error paths, which are unaffected by this change.
- Existing tests status: `supabase test db` — 210/210 passing after `supabase db reset`
  with this migration applied.
- Manual testing performed: via `psql`, confirmed (1) a `P0001` validation error
  (`invalid transaction_type`) still surfaces its original descriptive message unchanged,
  and (2) `bulk_insert_transactions`'s per-row classification logic is applied correctly.
- Edge cases tested: validation-error passthrough vs. catch-all sanitization paths.
- Test files modified or added: none.