### PR TITLE
docs: warn against setting SUPABASE_SERVICE_ROLE_KEY in Vercel

### DIFF
--- a/docs/deployment/environment-variables.md
+++ b/docs/deployment/environment-variables.md
@@ -12,6 +12,12 @@
 
 ## Optional / Recommended for Production
 
+## Local/CI-Only — Never Set in Vercel
+
+### SUPABASE_SERVICE_ROLE_KEY
+- Description: Supabase service role key with elevated (RLS-bypassing) privileges. Used only by Playwright e2e tests (`apps/web-next/e2e/utils/test-helpers.ts`) for admin operations like creating/deleting test users.
+- ⚠️ **Never add this as a Vercel project environment variable.** It must stay local/CI-only (e.g. a CI secret injected only for the e2e job). The only Supabase keys that belong in Vercel are `VITE_SUPABASE_URL` and `VITE_SUPABASE_KEY` — anything prefixed `VITE_` is bundled into the client build, so this key must never be given that prefix or added to a build's env vars.
+
 ## Notes & Validation
 - Ensure `SITE_URL` is set correctly in production; email links are generated using this value.
 - For local development set `SITE_URL=http://localhost:3000` before starting Supabase so email links point to your dev site.

--- a/docs/superpowers/plans/2026-07-18-security-review-fixes.md
+++ b/docs/superpowers/plans/2026-07-18-security-review-fixes.md
@@ -206,7 +206,7 @@ and for the three `RAISE EXCEPTION '...failed: %', SQLERRM` catch-alls, drop the
 
 Also flag as a documentation-debt item (not part of this fix, just noted): `docs/api/bulk-upload.md` describes a different, more structured error shape than what the SQL actually returns — worth reconciling separately.
 
-### Service role key — process guard, not code
+### ✅ Done — Service role key — process guard, not code
 
 `SUPABASE_SERVICE_ROLE_KEY` is correctly gitignored and un-prefixed (won't be bundled by Vite); used only in `apps/web-next/e2e/utils/test-helpers.ts` for Playwright admin operations. `vercel.json` has no `env`/`build.env` block referencing it today, so there's no active leak — but `docs/deployment/environment-variables.md` currently documents only `SITE_URL` and doesn't mention this key at all. Add a short explicit warning there: this key must never be added as a Vercel project env var (only `VITE_SUPABASE_URL`/`VITE_SUPABASE_KEY` belong there), since it's a local/CI-only secret for e2e admin operations.
 


### PR DESCRIPTION
## Why

Last "worth-doing" item from the 2026-07-18 security review
(docs/superpowers/plans/2026-07-18-security-review-fixes.md). SUPABASE_SERVICE_ROLE_KEY is
correctly gitignored and un-prefixed (so Vite won't bundle it), and is only used locally/in CI
by Playwright e2e tests (apps/web-next/e2e/utils/test-helpers.ts) for admin operations. There
was no active leak, but nothing documented that this key must never be added as a Vercel
project env var — vercel.json currently has no env/build.env block referencing it, so this is
a preventive doc fix, not a code change.

## What Changed

- Files or areas updated: `docs/deployment/environment-variables.md`
- New functionality added: a new "Local/CI-Only — Never Set in Vercel" section documenting
  `SUPABASE_SERVICE_ROLE_KEY`'s purpose and an explicit warning that only `VITE_SUPABASE_URL`
  and `VITE_SUPABASE_KEY` belong in Vercel.
- Existing behavior changed: none — documentation only.

## Testing

- New tests added: none (docs-only change).
- Existing tests status: unaffected.
- Manual testing performed: confirmed via grep that `SUPABASE_SERVICE_ROLE_KEY` is still only
  referenced in `apps/web-next/e2e/utils/test-helpers.ts`.