### PR TITLE
docs: add plan tracking template with status/progress log

### DIFF
--- a/docs/superpowers/plans/2026-07-25-deep-code-review-fixes.md
+++ b/docs/superpowers/plans/2026-07-25-deep-code-review-fixes.md
@@ -1,8 +1,17 @@
 # Deep code review fixes — implementation plan
 
 **Date:** 2026-07-25
+**Status:** Not started
 **Source:** `docs/superpowers/plans/2026-07-18-project-review-security-code-ux.md` §2 (Deep code review)
 **Scope:** C1-C5 and the smaller points from that section. The security findings (§1) from the same review were already fixed in an earlier batch (PRs #238-#240). UX findings (§3) are out of scope here.
+
+## Progress Log
+
+<!-- Newest entry first. One entry per session, even sessions with no code progress. -->
+
+- **2026-07-25** — Plan created (PR #242). Not started.
+
+---
 
 Every finding below was independently re-verified against the current repo (2026-07-25) via three parallel Explore agents plus direct reads of `node_modules/@refinedev/{core,antd,supabase}` source — not just trusted from the original review, which is a week stale and, in one case (C2), already resolved by an unrelated PR.
 
@@ -32,7 +41,7 @@ Swap `resource: "tags"` → `"tags_with_usage"` and `resource: "bank_accounts"` 
 
 **Out of scope, intentionally:** `transactions/show.tsx` (category/bank-account `useOne` lookups) — showing a soft-deleted entity's historical name on an already-created transaction is correct behavior, not a bug; switching it to the `_with_usage` view would break that.
 
-**Known follow-up, not fixed here:** `tags_with_usage.in_use_count` aggregates via the legacy `transactions.tags TEXT[]` column (`UNNEST`) rather than the `transaction_tags` junction table the actual RPCs write to — likely already inaccurate. Separate, pre-existing issue; flag but don't touch.
+**Known follow-up, not fixed here:** `tags_with_usage.in_use_count` aggregates via the legacy `transactions.tags TEXT[]` column (`UNNEST`) rather than the `transaction_tags` junction table the actual RPCs write to — likely already inaccurate. Folded into §6 below (legacy denormalized columns cleanup) rather than fixed in isolation.
 
 ---
 
@@ -137,14 +146,14 @@ Replace the `Table.Column key="tag_ids"` block's `filterDropdown` with a small l
 
 ## Implementation order
 
-1. **C5 migration first, in isolation** — write, apply locally (`supabase db reset`), write + run the new pgTAP tests until green, *before* touching frontend code.
-2. Regenerate types (`supabase gen types typescript --local`) and sync into `apps/web-next/src/types/database.types.ts`.
-3. **C5 frontend** — `rpc.ts` → `useBudgetForm.ts` → `budgets/create.tsx`/`edit.tsx` refactor. Run `apps/web-next/e2e/tests/budgets.spec.ts` to confirm the happy path still works end-to-end against the new RPC.
-4. **C1** — mechanical resource-name swaps across the six files + header search. Manually verify: soft-delete a tag/bank account, confirm it disappears from every affected dropdown/search.
-5. **C3** — install + wire the antd patch. Verify console warning gone, `npm run build` clean.
-6. **Tag filter fix** — write the new e2e test first (should currently fail/error against unfixed code, confirming the bug is real), then implement, confirm it goes green. Manually check the Network tab shows `.or(...)`/`cs` syntax, not `tag_ids=in.(...)`.
-7. **Cleanup points** — retry.ts deletion, ESLint dedup, Dockerfile deletion. Low risk, verify via `npm run lint` / `npm run build` / `npm run check-types`.
-8. **Final regression pass**: `npm run test:unit`, `npm run test:e2e:ci`, `npm run lint`, `npm run check-types`, plus the full pgTAP suite (`supabase test db`).
+- [ ] 1. **C5 migration first, in isolation** — write, apply locally (`supabase db reset`), write + run the new pgTAP tests until green, *before* touching frontend code.
+- [ ] 2. Regenerate types (`supabase gen types typescript --local`) and sync into `apps/web-next/src/types/database.types.ts`.
+- [ ] 3. **C5 frontend** — `rpc.ts` → `useBudgetForm.ts` → `budgets/create.tsx`/`edit.tsx` refactor. Run `apps/web-next/e2e/tests/budgets.spec.ts` to confirm the happy path still works end-to-end against the new RPC.
+- [ ] 4. **C1** — mechanical resource-name swaps across the six files + header search. Manually verify: soft-delete a tag/bank account, confirm it disappears from every affected dropdown/search.
+- [ ] 5. **C3** — install + wire the antd patch. Verify console warning gone, `npm run build` clean.
+- [ ] 6. **Tag filter fix** — write the new e2e test first (should currently fail/error against unfixed code, confirming the bug is real), then implement, confirm it goes green. Manually check the Network tab shows `.or(...)`/`cs` syntax, not `tag_ids=in.(...)`.
+- [ ] 7. **Cleanup points** — retry.ts deletion, ESLint dedup, Dockerfile deletion. Low risk, verify via `npm run lint` / `npm run build` / `npm run check-types`.
+- [ ] 8. **Final regression pass**: `npm run test:unit`, `npm run test:e2e:ci`, `npm run lint`, `npm run check-types`, plus the full pgTAP suite (`supabase test db`).
 
 ## Critical files
 

--- a/docs/superpowers/plans/2026-07-25-transactions-csv-export.md
+++ b/docs/superpowers/plans/2026-07-25-transactions-csv-export.md
@@ -1,6 +1,14 @@
 # Transactions CSV Export Implementation Plan
 
+**Date:** 2026-07-25
+**Status:** Not started
 **Goal:** Let a user export their own transactions for a date range they choose to a CSV file, from the Settings > Import & Export tab, with fields: date, transaction type, category (hierarchy joined with `/`), bank account, amount, tags (sorted, `;`-joined), notes.
+
+## Progress Log
+
+<!-- Newest entry first. One entry per session, even sessions with no code progress. -->
+
+- **2026-07-25** — Plan created (PR #241). Not started.
 
 **Architecture:** No new database objects are needed — the existing `transactions_with_details` view (added in `supabase/migrations/20260627120000_transaction_category_parent_labels.sql`) already resolves category parent/child names and pre-sorts/aggregates tag names (`ARRAY_AGG(... ORDER BY tg.name)`), scoped by RLS to the current user. The frontend adds:
 1. A pure CSV-serialization utility (escaping, row building, browser download).

--- a/docs/superpowers/plans/TEMPLATE.md
+++ b/docs/superpowers/plans/TEMPLATE.md
@@ -1,0 +1,64 @@
+<!--
+HOW TO USE THIS TEMPLATE (delete this whole comment block once you copy the file):
+
+- Copy to docs/superpowers/plans/YYYY-MM-DD-short-feature-name.md and fill in.
+- This doc is the single source of truth for progress tracking on the plan — don't also
+  track progress in a separate doc or as a GitHub issue checklist. One thing to keep in sync,
+  not two.
+- Every session that touches this plan — including one that makes no code progress — ends
+  with: update **Status**, and prepend a **Progress Log** entry. That's what makes the plan
+  resumable days later without reconstructing state from git log.
+- Progress Log is newest-entry-first. Resuming should only require reading the top entry.
+- The **Implementation order** section is the actual checklist — check items off as they land,
+  ideally in the same commit/PR that completes the step.
+- If reality diverges from the plan mid-implementation, note it inline where it happened.
+  Don't rewrite history — a plan being wrong in hindsight is fine, hiding that it was wrong
+  is not.
+- Only open a GitHub issue for the plan as a whole, and only if it's worth tracking
+  externally (e.g. cross-referencing from PRs via "Closes #N"). Don't open one issue per
+  step — this doc is the per-step tracker, GitHub issues stay for what's already sparse
+  in this repo: user-facing bugs/features.
+-->
+
+# <Feature name> — implementation plan
+
+**Date:** YYYY-MM-DD
+**Status:** Not started
+**Issue:** _(optional — `#NNN` if this plan is worth tracking as a GitHub issue too)_
+**Source:** _(optional — link to the research/review doc this plan came from)_
+**Scope:** _One or two sentences: what's in, what's explicitly out._
+
+## Progress Log
+
+<!-- Newest entry first. One entry per session, even sessions with no code progress. -->
+
+- **YYYY-MM-DD** — Plan created. Not started.
+
+---
+
+## 1. <Finding / task title>
+
+<Description, root cause, files involved, the fix.>
+
+---
+
+## 2. <Next finding / task title>
+
+...
+
+---
+
+## Implementation order
+
+- [ ] 1. <step, in the order it should be done>
+- [ ] 2. <step>
+- [ ] 3. <step>
+
+## Critical files
+
+- `path/to/file` — <why it matters>
+
+## Verification plan
+
+1. <command or manual check>
+2. <command or manual check>


### PR DESCRIPTION
## Why

Multi-step implementation plans in docs/superpowers/plans/ often span multiple
sessions across several days. There was no consistent way to tell, at a glance,
what's done and what to pick up next — resuming meant re-deriving state from git
log or re-reading the whole plan. This establishes a lightweight convention so
each plan doc is self-tracking.

## What Changed

- Files or areas updated: `docs/superpowers/plans/`
- New functionality added:
  - `TEMPLATE.md` — a plan template with a `Status` line, a newest-first
    `Progress Log` (one entry per session, even sessions with no code progress),
    and a checkbox-based step list, plus inline usage notes explaining the
    convention.
  - Retrofitted `2026-07-25-deep-code-review-fixes.md` and
    `2026-07-25-transactions-csv-export.md` with `Status`/`Progress Log`
    sections as worked examples (both currently "Not started" — confirmed via
    git log that no implementation work has landed on either yet).
- Existing behavior changed: none — this is docs-only.

## Key Decisions

- Decision: track progress inside each plan doc itself, not via a GitHub issue
  per plan step or a separate tracking doc.
- Reasoning: a single source of truth avoids sync drift between two systems;
  resuming a session is just "read the doc." Matches how most existing plans
  already used ad-hoc checkboxes, and mirrors this repo's existing pattern of
  dedicated doc-status commits (e.g. `chore/mark-docs-done`,
  `docs/update-plan-statuses`).
- Alternatives considered: one GitHub issue per plan step (rejected — too much
  sync overhead for solo/small-team use); a separate tracking doc per plan
  (rejected — redundant with the plan doc). A GitHub issue at the whole-plan
  level (not per-step) remains a fine option when external visibility is
  wanted, referenced via `Closes #N` on the implementing PR.

## How This Affects the System

- User-facing changes: none.
- API changes: none.
- Performance implications: none.
- Database changes: none.
- Breaking changes: none.

## Testing

- New tests added: n/a (docs-only change).
- Existing tests status: unaffected.
- Manual testing performed: n/a.
- Edge cases tested: n/a.
- Test files modified or added: none.