### PR TITLE
fix: hide soft-deleted tags/bank accounts from dropdowns & search (C1)

### DIFF
--- a/apps/web-next/src/components/header/index.tsx
+++ b/apps/web-next/src/components/header/index.tsx
@@ -170,14 +170,14 @@ export const Header: React.FC<RefineThemedLayoutHeaderProps> = ({
   });
 
   const { query: catQuery } = useList({
-    resource: "categories",
+    resource: "categories_with_usage",
     filters: [{ field: "name", operator: "contains", value }],
     pagination: { pageSize: 5 },
     queryOptions: { enabled: false },
   });
 
   const { query: bankQuery } = useList({
-    resource: "bank_accounts",
+    resource: "bank_accounts_with_usage",
     filters: [{ field: "name", operator: "contains", value }],
     pagination: { pageSize: 5 },
     queryOptions: { enabled: false },

--- a/apps/web-next/src/pages/budgets/create.tsx
+++ b/apps/web-next/src/pages/budgets/create.tsx
@@ -40,7 +40,7 @@ export const BudgetCreate = () => {
   });
 
   const { query: tagsQuery } = useList({
-    resource: "tags",
+    resource: "tags_with_usage",
     pagination: { mode: "off" },
     sorters: [{ field: "name", order: "asc" }],
   });

--- a/apps/web-next/src/pages/budgets/edit.tsx
+++ b/apps/web-next/src/pages/budgets/edit.tsx
@@ -49,7 +49,7 @@ export const BudgetEdit = () => {
   });
 
   const { query: tagsQuery } = useList({
-    resource: "tags",
+    resource: "tags_with_usage",
     pagination: { mode: "off" },
     sorters: [{ field: "name", order: "asc" }],
   });

--- a/apps/web-next/src/pages/transactions/create.tsx
+++ b/apps/web-next/src/pages/transactions/create.tsx
@@ -75,7 +75,7 @@ export const TransactionCreate = () => {
     }));
 
   const { options: tagOptions, query: tagsQuery } = useCoreSelect({
-    resource: "tags",
+    resource: "tags_with_usage",
     optionLabel: "name",
     optionValue: "id",
     pagination: { mode: "off" },
@@ -83,7 +83,7 @@ export const TransactionCreate = () => {
   });
 
   const { selectProps: bankAccountSelectProps } = useAntSelect({
-    resource: "bank_accounts",
+    resource: "bank_accounts_with_usage",
     optionLabel: "name",
     pagination: { mode: "off" },
     sorters: [{ field: "name", order: "asc" }],

--- a/apps/web-next/src/pages/transactions/edit.tsx
+++ b/apps/web-next/src/pages/transactions/edit.tsx
@@ -87,7 +87,7 @@ export const TransactionEdit = () => {
   }, [categoriesResult?.data, currentCategoryId]);
 
   const { selectProps: bankAccountSelectProps } = useAntSelect({
-    resource: "bank_accounts",
+    resource: "bank_accounts_with_usage",
     defaultValue: transactionsData?.bank_account_id,
     optionLabel: "name",
     pagination: { mode: "off" },
@@ -96,7 +96,7 @@ export const TransactionEdit = () => {
 
   // Fetch all available tags
   const { options: tagOptions, query: tagsQuery } = useCoreSelect({
-    resource: "tags",
+    resource: "tags_with_usage",
     optionLabel: "name",
     optionValue: "id",
     pagination: { mode: "off" },

--- a/apps/web-next/src/pages/transactions/list.tsx
+++ b/apps/web-next/src/pages/transactions/list.tsx
@@ -100,7 +100,7 @@ export const TransactionList = () => {
 
   // Bank account select
   const { selectProps: bankAccountSelectProps } = useSelect({
-    resource: "bank_accounts",
+    resource: "bank_accounts_with_usage",
     optionLabel: "name",
     optionValue: "id",
     ...commonSelectOptions,
@@ -109,7 +109,7 @@ export const TransactionList = () => {
 
   // Tags select
   const { selectProps: tagSelectProps } = useSelect({
-    resource: "tags",
+    resource: "tags_with_usage",
     optionLabel: "name",
     optionValue: "id",
     ...commonSelectOptions,

--- a/docs/superpowers/plans/2026-07-25-deep-code-review-fixes.md
+++ b/docs/superpowers/plans/2026-07-25-deep-code-review-fixes.md
@@ -1,7 +1,7 @@
 # Deep code review fixes — implementation plan
 
 **Date:** 2026-07-25
-**Status:** Not started
+**Status:** In progress
 **Source:** `docs/superpowers/plans/2026-07-18-project-review-security-code-ux.md` §2 (Deep code review)
 **Scope:** C1-C5 and the smaller points from that section. The security findings (§1) from the same review were already fixed in an earlier batch (PRs #238-#240). UX findings (§3) are out of scope here.
 
@@ -9,6 +9,7 @@
 
 <!-- Newest entry first. One entry per session, even sessions with no code progress. -->
 
+- **2026-07-26** — Step 4 (C1) done, shipped ahead of steps 1-3 (branch `fix/c1-soft-deleted-visibility`, split out of `fix/atomic-budget-with-links` since C1 is fully independent of the C5 work-in-progress on that branch): swapped `resource:` from raw tables to the `_with_usage` views in `transactions/create.tsx` (tags, bank accounts), `transactions/list.tsx` (bank account + tag filters), `transactions/edit.tsx` (bank accounts, tags), `budgets/create.tsx` and `budgets/edit.tsx` (tags), and `components/header/index.tsx` (categories, bank accounts — global search). `npm run check-types`/`lint`/`build` all clean. Manually verified via Playwright against the local dev server + local Supabase: soft-deleted the "movie" tag and "Chase" bank account, confirmed both vanish from the transaction-create tag/bank-account dropdowns and from the header global search, while an existing (non-deleted) account still shows up in search. Full e2e suites for `transactions.spec.ts` (26/26) and `budgets.spec.ts` (11/11) pass; `supabase test db` still 233/233 after a fresh `db reset` (to restore seed data touched during manual testing). `transactions/show.tsx` deliberately left alone (shows historical name on already-created transactions — correct, not a bug). PR opened for this branch; C5 (steps 1-3) continues separately on `fix/atomic-budget-with-links`.
 - **2026-07-25** — Plan created (PR #242). Not started.
 
 ---
@@ -149,7 +150,7 @@ Replace the `Table.Column key="tag_ids"` block's `filterDropdown` with a small l
 - [ ] 1. **C5 migration first, in isolation** — write, apply locally (`supabase db reset`), write + run the new pgTAP tests until green, *before* touching frontend code.
 - [ ] 2. Regenerate types (`supabase gen types typescript --local`) and sync into `apps/web-next/src/types/database.types.ts`.
 - [ ] 3. **C5 frontend** — `rpc.ts` → `useBudgetForm.ts` → `budgets/create.tsx`/`edit.tsx` refactor. Run `apps/web-next/e2e/tests/budgets.spec.ts` to confirm the happy path still works end-to-end against the new RPC.
-- [ ] 4. **C1** — mechanical resource-name swaps across the six files + header search. Manually verify: soft-delete a tag/bank account, confirm it disappears from every affected dropdown/search.
+- [x] 4. **C1** — mechanical resource-name swaps across the six files + header search. Manually verify: soft-delete a tag/bank account, confirm it disappears from every affected dropdown/search.
 - [ ] 5. **C3** — install + wire the antd patch. Verify console warning gone, `npm run build` clean.
 - [ ] 6. **Tag filter fix** — write the new e2e test first (should currently fail/error against unfixed code, confirming the bug is real), then implement, confirm it goes green. Manually check the Network tab shows `.or(...)`/`cs` syntax, not `tag_ids=in.(...)`.
 - [ ] 7. **Cleanup points** — retry.ts deletion, ESLint dedup, Dockerfile deletion. Low risk, verify via `npm run lint` / `npm run build` / `npm run check-types`.


### PR DESCRIPTION
## Why

Several `resource:` calls queried the raw `tags`/`bank_accounts` tables directly instead of the `tags_with_usage`/`bank_accounts_with_usage` views, so soft-deleted tags and bank accounts kept showing up in transaction/budget create/edit forms and in the global header search. Categories already went through `categories_with_usage` correctly — this brings tags and bank accounts in line. Root-caused in `docs/superpowers/plans/2026-07-18-project-review-security-code-ux.md` (C1), scoped into `docs/superpowers/plans/2026-07-25-deep-code-review-fixes.md`.

## What Changed

- Files or areas updated: `transactions/create.tsx` (tags, bank accounts), `transactions/list.tsx` (bank account + tag filters), `transactions/edit.tsx` (bank accounts, tags), `budgets/create.tsx` / `budgets/edit.tsx` (tags), `components/header/index.tsx` (categories, bank accounts — global search).
- New functionality added: none.
- Existing behavior changed: dropdowns and search now query `tags_with_usage` / `bank_accounts_with_usage` / `categories_with_usage` instead of the raw tables — soft-deleted entries no longer appear.

## Key Decisions

- Decision: pure resource-name swap, no migration — the `_with_usage` views already exist (added in `20260227201422_add_soft_delete.sql`), already filter `deleted_at IS NULL`, and already match the raw tables' column shape (`id`/`name`/`description`/`in_use_count`/etc).
- Reasoning: mechanical, low-risk fix; avoids touching schema for a pure visibility bug.
- Alternatives considered: none — this mirrors the pattern categories already used correctly.
- `transactions/show.tsx` intentionally left unchanged: showing a soft-deleted entity's historical name on an already-created transaction is correct behavior, not a bug.

## How This Affects the System

- User-facing changes: soft-deleted tags/bank accounts disappear from all transaction/budget forms and header search (previously they lingered).
- API changes: none.
- Performance implications: none — views are already used elsewhere for the same tables.
- Database changes: none (no migration).
- Breaking changes: none.

## Testing

- New tests added: none (no new automated test for this specific fix — see manual testing below).
- Existing tests status: `npm run check-types`, `npm run lint`, `npm run build` all clean. Full `transactions.spec.ts` (26/26) and `budgets.spec.ts` (11/11) e2e suites pass. `supabase test db` unaffected (233/233, no DB changes in this PR).
- Manual testing performed: via Playwright against local dev server + local Supabase — soft-deleted the "movie" tag and "Chase" bank account, confirmed both disappear from the transaction-create tag/bank-account dropdowns and from the header global search dropdown, while a live (non-deleted) account still appears in search.
- Edge cases tested: search returning zero results for a deleted entity's name (no crash, empty dropdown) vs. still returning results for a live entity.
- Test files modified or added: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)