### PR TITLE
fix(db): exclude soft-deleted tags from get_transaction_tags RPC

### DIFF
--- a/supabase/migrations/20260801090343_fix_get_transaction_tags_soft_delete.sql
+++ b/supabase/migrations/20260801090343_fix_get_transaction_tags_soft_delete.sql
@@ -1,0 +1,25 @@
+-- get_transaction_tags joined tags without excluding soft-deleted rows, so a transaction
+-- could show a tag that the user had already (soft-)deleted. Add the deleted_at IS NULL
+-- filter used everywhere else tags are joined.
+CREATE
+OR REPLACE FUNCTION public.get_transaction_tags (p_transaction_id UUID) RETURNS jsonb LANGUAGE SQL STABLE SECURITY DEFINER
+SET
+  search_path = '' AS $$
+    SELECT COALESCE(
+        jsonb_agg(
+            jsonb_build_object(
+                'id', t.id,
+                'name', t.name,
+                'description', t.description
+            ) ORDER BY t.name
+        ) FILTER (WHERE t.id IS NOT NULL),
+        '[]'::jsonb
+    )
+    FROM public.transaction_tags tt
+    JOIN public.tags t ON tt.tag_id = t.id AND t.deleted_at IS NULL
+    WHERE tt.transaction_id = p_transaction_id
+      AND EXISTS (
+        SELECT 1 FROM public.transactions t2
+        WHERE t2.id = p_transaction_id AND t2.user_id = auth.uid()
+      );
+$$;

--- a/supabase/tests/transaction_tags_test.sql
+++ b/supabase/tests/transaction_tags_test.sql
@@ -2,7 +2,7 @@ begin;
 
 create extension if not exists pgtap with schema extensions;
 
-select plan(18);
+select plan(20);
 
 -- Create two test users
 select tests.create_supabase_user('tx_user1@test.com');
@@ -176,6 +176,40 @@ SELECT results_eq(
     ) $$,
   $$ SELECT '[]'::jsonb $$,
   'User2 cannot read User1 transaction tags via get_transaction_tags'
+);
+
+-- 12) get_transaction_tags excludes soft-deleted tags
+select tests.authenticate_as('tx_user1@test.com');
+
+INSERT INTO public.tags (user_id, name) VALUES (auth.uid(), 'SoftDelTag') ON CONFLICT DO NOTHING;
+INSERT INTO public.transactions (user_id, date, type, amount, category_id, bank_account_id)
+VALUES (
+  auth.uid(), '2025-01-04', 'spend'::public.transaction_type, 75,
+  (SELECT id FROM public.categories WHERE user_id = auth.uid() AND name = 'TestCat' LIMIT 1),
+  (SELECT id FROM public.bank_accounts WHERE user_id = auth.uid() AND name = 'TestAccount' LIMIT 1)
+) ON CONFLICT DO NOTHING;
+INSERT INTO public.transaction_tags (transaction_id, tag_id)
+VALUES (
+  (SELECT id FROM public.transactions WHERE user_id = auth.uid() AND date = '2025-01-04' LIMIT 1),
+  (SELECT id FROM public.tags WHERE user_id = auth.uid() AND name = 'SoftDelTag' LIMIT 1)
+) ON CONFLICT DO NOTHING;
+
+SELECT results_eq(
+  $$ SELECT (public.get_transaction_tags(
+      (SELECT id FROM public.transactions WHERE user_id = auth.uid() AND date = '2025-01-04' LIMIT 1)
+    ) -> 0 ->> 'name') $$,
+  $$ SELECT 'SoftDelTag' $$,
+  'get_transaction_tags returns tag before soft delete'
+);
+
+UPDATE public.tags SET deleted_at = now() WHERE user_id = auth.uid() AND name = 'SoftDelTag';
+
+SELECT results_eq(
+  $$ SELECT public.get_transaction_tags(
+      (SELECT id FROM public.transactions WHERE user_id = auth.uid() AND date = '2025-01-04' LIMIT 1)
+    ) $$,
+  $$ SELECT '[]'::jsonb $$,
+  'get_transaction_tags excludes soft-deleted tags'
 );
 
 -- Finish


### PR DESCRIPTION
## Why

A Copilot review comment on PR #255 flagged that `get_transaction_tags` joins `tags` without filtering `deleted_at`, so a transaction could still show a tag the user had soft-deleted — inconsistent with every other tag join in the schema (e.g. `budgets_with_linked`, `atomic_transaction_with_tags`, `atomic_budget_with_links`).

## What Changed

- Files or areas updated: `supabase/migrations/20260801090343_fix_get_transaction_tags_soft_delete.sql`, `supabase/tests/transaction_tags_test.sql`
- New functionality added: none
- Existing behavior changed: `get_transaction_tags` now adds `AND t.deleted_at IS NULL` to the `tags` join (`SECURITY DEFINER`, ownership check, and return shape are unchanged)

## Key Decisions

- Decision: added a new migration rather than editing `20260718204224_fix_transaction_tags_idor_and_category_ownership.sql`
- Reasoning: that migration is already merged to `main`/`release`, and the repo's migration workflow forbids editing already-merged migration files
- Alternatives considered: none — this is the standard pattern used elsewhere in the schema for soft-deleted tag joins

## How This Affects the System

- User-facing changes: a transaction's tag list will no longer include tags the user has deleted
- API changes: none (RPC signature unchanged)
- Performance implications: none
- Database changes: new migration, no schema/table changes
- Breaking changes: none

## Testing

- New tests added: extended `transaction_tags_test.sql` with a case asserting `get_transaction_tags` returns the tag before soft delete and excludes it after
- Existing tests status: passing
- Manual testing performed: `supabase db reset` + `supabase test db` locally — all 247 tests pass across 17 files
- Edge cases tested: soft-deleted tag exclusion
- Test files modified or added: `supabase/tests/transaction_tags_test.sql`