### PR TITLE
chore: add docs index to AGENTS.md and document soft-delete incident

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,23 @@ npm run test:e2e:ci -- e2e/tests/transactions.spec.ts -g "user can add tags"
 
 ⚠️ **Every schema change MUST go through a migration file.** Never modify a migration that has already merged to `main` — always create a new one instead (`supabase migration new <name>`). Full workflow, Supabase CLI commands, conventions, and local ports: [`docs/database/schema-and-migrations.md`](docs/database/schema-and-migrations.md)
 
+## Documentation
+
+Check these before starting work in the relevant area — don't guess at conventions that are already written down.
+
+| Doc | When to read it |
+|---|---|
+| [`docs/getting-started.md`](docs/getting-started.md) | Local setup, prerequisites, common commands |
+| [`docs/database/schema-and-migrations.md`](docs/database/schema-and-migrations.md) | Any schema/migration change, RLS, `SECURITY DEFINER` rules |
+| [`docs/api/bulk-upload.md`](docs/api/bulk-upload.md) | Working on the `bulk_upload_data` RPC / bulk import |
+| [`docs/deployment/release-howto.md`](docs/deployment/release-howto.md) | Cutting a release, syncing `main` → `release` |
+| [`docs/deployment/environment-variables.md`](docs/deployment/environment-variables.md) | Env vars, secrets, Vercel config |
+| [`docs/deployment/email-templates-setup.md`](docs/deployment/email-templates-setup.md) | Auth email templates (Supabase hosted or self-managed) |
+| [`docs/deployment/redirect-urls-setup.md`](docs/deployment/redirect-urls-setup.md) | Auth redirect URL configuration |
+| [`docs/deployment/password-reset-deployment-checklist.md`](docs/deployment/password-reset-deployment-checklist.md) | Password reset / magic link flow changes |
+| [`docs/improvement-roadmap.md`](docs/improvement-roadmap.md) | Picking up the next planned improvement |
+| [`docs/superpowers/plans/`](docs/superpowers/plans/) & [`specs/`](docs/superpowers/specs/) | Historical plan/spec docs for past features — background context, not current state |
+
 ## Environment Configuration
 
 - Local development: `apps/web-next/.env.local`

--- a/docs/database/schema-and-migrations.md
+++ b/docs/database/schema-and-migrations.md
@@ -59,6 +59,10 @@ SELECT ...
 
 User-facing tables (`transactions`, `categories`, `bank_accounts`, `tags`) have a `deleted_at TIMESTAMPTZ DEFAULT NULL` column (added in `20260227201422_add_soft_delete.sql`) instead of ever being hard-deleted. Deletion goes through dedicated RPCs — `delete_category_safe`, `delete_bank_account_safe`, `delete_tag_safe` — which check whether the row is still referenced (e.g. a category still used by transactions) and return `(ok boolean, in_use_count bigint)` rather than throwing, so the caller can decide what to do instead of it being an error. Any new view, RPC, or query that reads one of these tables **must** filter `deleted_at IS NULL`, or it will leak soft-deleted rows.
 
+This has happened in this codebase: `get_transaction_tags`, added in `20260718204224_fix_transaction_tags_idor_and_category_ownership.sql`, joined `tags` without a `deleted_at IS NULL` filter, so a transaction could still show a tag the user had already deleted. It was caught in code review after merge and fixed in `20260801090343_fix_get_transaction_tags_soft_delete.sql` (PR #257).
+
+**Rule of thumb when writing or reviewing any view/RPC/query touching `transactions`, `categories`, `bank_accounts`, or `tags`:** add `deleted_at IS NULL` on every join to one of these tables, not just the top-level `WHERE` — a join without the filter leaks soft-deleted rows just as easily as a bare `SELECT`.
+
 ### Standard 4-policy RLS shape
 
 Every user-facing table gets exactly four RLS policies, named `<table>_select` / `<table>_insert` / `<table>_update` / `<table>_delete`, each scoped with the identical predicate `user_id = (SELECT auth.uid())` (wrapped in a `SELECT` so Postgres can cache/inline it instead of re-evaluating `auth.uid()` per row — see `20260201164000_baseline_from_schemas.sql:190-236`). When adding a new user table, copy this exact template rather than writing a combined or ad-hoc policy.


### PR DESCRIPTION
## Why

Two gaps in how the docs help an agent working in this repo:

1. `AGENTS.md` only linked to the migrations doc, so `docs/deployment/*`, `docs/api/*`, and `docs/getting-started.md` had no pointer — an agent had to stumble onto them.
2. The soft-delete rule in `docs/database/schema-and-migrations.md` was correct but abstract. PR #255 introduced `get_transaction_tags` without a `deleted_at IS NULL` filter on its `tags` join, violating that exact rule, and it wasn't caught until Copilot's review comment (fixed in PR #257). A concrete incident makes the rule harder to miss, the same way the existing `SECURITY DEFINER` section already cites the `get_transaction_tags` IDOR incident.

## What Changed

- Files or areas updated: `AGENTS.md`, `docs/database/schema-and-migrations.md`
- New functionality added: none
- Existing behavior changed: documentation only

Specifically:
- `AGENTS.md`: added a "Documentation" section with a table linking every doc under `docs/` and when to read it.
- `docs/database/schema-and-migrations.md`: added a short incident note under "Soft delete, not hard delete" referencing the `get_transaction_tags` bug and PR #257, plus a rule-of-thumb that `deleted_at IS NULL` must be applied per-join, not just at the top-level `WHERE`.

## Key Decisions

- Decision: kept the incident note next to the existing rule rather than creating a new "lessons learned" doc
- Reasoning: matches the pattern already established for the `SECURITY DEFINER` ownership-check section in the same file — one place, rule + concrete example
- Alternatives considered: a separate incidents/postmortems doc — rejected as unnecessary indirection for a single sentence

## How This Affects the System

- User-facing changes: none
- API changes: none
- Performance implications: none
- Database changes: none
- Breaking changes: none

## Testing

- New tests added: n/a (docs only)
- Existing tests status: n/a
- Manual testing performed: read through both files to confirm links/anchors resolve
- Edge cases tested: n/a
- Test files modified or added: none