### PR TITLE
chore: add create-release.sh script

### DIFF
--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ -z "${RELEASE_VERSION:-}" ]; then
+  echo "Usage: RELEASE_VERSION=vX.Y.Z $0" >&2
+  exit 1
+fi
+
+if ! [[ "$RELEASE_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "RELEASE_VERSION must look like vX.Y.Z (got: $RELEASE_VERSION)" >&2
+  exit 1
+fi
+
+REPO_URL="https://github.com/iguliaev/moneylens.git"
+
+TMP_DIR="$(mktemp -d -t moneylens-release-XXXXXX)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+echo "Cloning fresh copy of the repo into $TMP_DIR"
+git clone "$REPO_URL" "$TMP_DIR"
+cd "$TMP_DIR"
+
+echo "Step 1 — Review what will be released"
+git checkout main && git pull origin main
+git fetch origin release:release
+git log release..main --oneline
+
+echo "Step 2 — Open a PR from main into release"
+gh pr create --base release --head main --title "release: $RELEASE_VERSION" --body "Production release $RELEASE_VERSION"
+
+echo "Merging release PR"
+gh pr merge --merge --subject "release: $RELEASE_VERSION"
+
+echo "Step 3 — Tag the release"
+git checkout release && git pull origin release
+git tag "$RELEASE_VERSION"
+git push origin "$RELEASE_VERSION"
+
+echo "Step 4 — Create a GitHub Release"
+gh release create "$RELEASE_VERSION" --title "$RELEASE_VERSION" --generate-notes --target release
+
+echo "Step 5 — Sync main"
+gh pr create --base main --head release --title "chore: sync release back to main" --body "Post-release sync"
+gh pr merge --merge
+
+echo "Release $RELEASE_VERSION complete"


### PR DESCRIPTION
## Why

We wanted a single script to drive the release process documented in
docs/deployment/release-howto.md, run in a way that can't be polluted by
local uncommitted changes or a stale local checkout.

## What Changed

- Files or areas updated: added `scripts/create-release.sh`
- New functionality added: a script that reads `RELEASE_VERSION` from the
  environment, validates it matches `vX.Y.Z`, clones a fresh copy of the
  repo into a temp directory, and runs the full release-howto.md flow
  there (PR main → release, merge, tag, GitHub release, sync PR back to
  main), logging each step.
- Existing behavior changed: none

## Key Decisions

- Decision: run everything against a fresh `git clone` in a `mktemp -d`
  directory instead of the caller's working copy.
  Reasoning: avoids any risk of releasing uncommitted/local-only state
  or leaving the caller's checkout on the wrong branch; temp dir is
  cleaned up via `trap ... EXIT`.
  Alternatives considered: operating directly in the current repo
  checkout — rejected due to risk of contaminating the release with
  local state.
- Decision: take `RELEASE_VERSION` from the environment (e.g.
  `RELEASE_VERSION=v1.2.3 ./scripts/create-release.sh`) rather than
  hardcoding it in the script.
  Reasoning: keeps the script reusable across releases without editing
  it each time.

## How This Affects the System

- User-facing changes: none
- API changes: none
- Performance implications: none
- Database changes: none
- Breaking changes: none

## Testing

- New tests added: none (shell script, not covered by test suite)
- Existing tests status: unaffected
- Manual testing performed: reviewed step-by-step against
  docs/deployment/release-howto.md; not yet run end-to-end against a
  real release
- Edge cases tested: missing/malformed `RELEASE_VERSION` (script exits
  with usage message)
- Test files modified or added: none