### PR TITLE
feat(transactions): default date, per-type entry defaults, and export range presets

### DIFF
--- a/apps/web-next/e2e/tests/settings-tabs.spec.ts
+++ b/apps/web-next/e2e/tests/settings-tabs.spec.ts
@@ -21,17 +21,19 @@ test.describe("Settings Tabs", () => {
     await loginUser(page, testUser.email, testUser.password);
   });
 
-  test("settings page displays three tabs", async ({ page }) => {
+  test("settings page displays four tabs", async ({ page }) => {
     await page.goto("/settings");
 
     const tabs = page.getByRole("tab");
-    await expect(tabs).toHaveCount(3);
+    await expect(tabs).toHaveCount(4);
 
     const generalTab = page.getByRole("tab", { name: /^general$/i });
+    const transactionsTab = page.getByRole("tab", { name: /^transactions$/i });
     const importExportTab = page.getByRole("tab", { name: /import.*export/i });
     const dangerZoneTab = page.getByRole("tab", { name: dangerZoneTabName });
 
     await expect(generalTab).toBeVisible();
+    await expect(transactionsTab).toBeVisible();
     await expect(importExportTab).toBeVisible();
     await expect(dangerZoneTab).toBeVisible();
   });

--- a/apps/web-next/e2e/tests/transaction-defaults.spec.ts
+++ b/apps/web-next/e2e/tests/transaction-defaults.spec.ts
@@ -33,6 +33,29 @@ async function openTransactionsSettingsTab(page: Page) {
   await expect(page.locator(".ant-spin-blur")).toHaveCount(0);
 }
 
+/**
+ * Picks an option, then waits for the shell to show it before returning.
+ *
+ * These Selects have no optimistic local state — their displayed value comes
+ * straight from the query result, which only updates once the write has been
+ * confirmed and refetched. Against local Supabase that round trip is fast
+ * enough to hide behind Playwright's normal action waits, but against a
+ * remote preview deployment it isn't: firing the next select (or navigating
+ * away) before this one's write has actually landed races the write. This
+ * helper makes that round trip an explicit, awaited step instead of an
+ * implicit assumption.
+ */
+async function setDefaultAndConfirm(
+  page: Page,
+  comboboxName: string,
+  optionTitle: string
+) {
+  await selectFromVisibleAntdDropdown(page, comboboxName, optionTitle);
+  await expect(selectShell(page, comboboxName)).toContainText(optionTitle, {
+    timeout: 15000,
+  });
+}
+
 test.describe("Transaction Defaults", () => {
   let testUser: { email: string; password: string; userId: string };
 
@@ -98,17 +121,9 @@ test.describe("Transaction Defaults", () => {
   test("defaults persist across a reload", async ({ page }) => {
     await openTransactionsSettingsTab(page);
 
-    await selectFromVisibleAntdDropdown(
-      page,
-      "Default transaction type",
-      "Spend"
-    );
-    await selectFromVisibleAntdDropdown(
-      page,
-      "Default category for Spend",
-      "Groceries"
-    );
-    await selectFromVisibleAntdDropdown(
+    await setDefaultAndConfirm(page, "Default transaction type", "Spend");
+    await setDefaultAndConfirm(page, "Default category for Spend", "Groceries");
+    await setDefaultAndConfirm(
       page,
       "Default bank account for Spend",
       "Main Account"
@@ -134,15 +149,12 @@ test.describe("Transaction Defaults", () => {
   test("a default can be cleared again", async ({ page }) => {
     await openTransactionsSettingsTab(page);
 
-    await selectFromVisibleAntdDropdown(
-      page,
-      "Default category for Earn",
-      "Salary"
-    );
+    await setDefaultAndConfirm(page, "Default category for Earn", "Salary");
 
     const shell = selectShell(page, "Default category for Earn");
     await shell.hover();
     await shell.locator(".ant-select-clear").click({ force: true });
+    await expect(shell).not.toContainText("Salary", { timeout: 15000 });
 
     await page.reload();
     await page.getByRole("tab", { name: /^transactions$/i }).click();
@@ -155,17 +167,9 @@ test.describe("Transaction Defaults", () => {
     page,
   }) => {
     await openTransactionsSettingsTab(page);
-    await selectFromVisibleAntdDropdown(
-      page,
-      "Default transaction type",
-      "Spend"
-    );
-    await selectFromVisibleAntdDropdown(
-      page,
-      "Default category for Spend",
-      "Groceries"
-    );
-    await selectFromVisibleAntdDropdown(
+    await setDefaultAndConfirm(page, "Default transaction type", "Spend");
+    await setDefaultAndConfirm(page, "Default category for Spend", "Groceries");
+    await setDefaultAndConfirm(
       page,
       "Default bank account for Spend",
       "Main Account"
@@ -193,22 +197,14 @@ test.describe("Transaction Defaults", () => {
     page,
   }) => {
     await openTransactionsSettingsTab(page);
-    await selectFromVisibleAntdDropdown(
-      page,
-      "Default category for Spend",
-      "Groceries"
-    );
-    await selectFromVisibleAntdDropdown(
+    await setDefaultAndConfirm(page, "Default category for Spend", "Groceries");
+    await setDefaultAndConfirm(
       page,
       "Default bank account for Spend",
       "Main Account"
     );
-    await selectFromVisibleAntdDropdown(
-      page,
-      "Default category for Earn",
-      "Salary"
-    );
-    await selectFromVisibleAntdDropdown(
+    await setDefaultAndConfirm(page, "Default category for Earn", "Salary");
+    await setDefaultAndConfirm(
       page,
       "Default bank account for Earn",
       "Secondary Account"
@@ -233,12 +229,8 @@ test.describe("Transaction Defaults", () => {
     page,
   }) => {
     await openTransactionsSettingsTab(page);
-    await selectFromVisibleAntdDropdown(
-      page,
-      "Default transaction type",
-      "Spend"
-    );
-    await selectFromVisibleAntdDropdown(
+    await setDefaultAndConfirm(page, "Default transaction type", "Spend");
+    await setDefaultAndConfirm(
       page,
       "Default bank account for Spend",
       "Main Account"
@@ -263,16 +255,8 @@ test.describe("Transaction Defaults", () => {
     page,
   }) => {
     await openTransactionsSettingsTab(page);
-    await selectFromVisibleAntdDropdown(
-      page,
-      "Default transaction type",
-      "Spend"
-    );
-    await selectFromVisibleAntdDropdown(
-      page,
-      "Default category for Spend",
-      "Groceries"
-    );
+    await setDefaultAndConfirm(page, "Default transaction type", "Spend");
+    await setDefaultAndConfirm(page, "Default category for Spend", "Groceries");
 
     // The FK is ON DELETE SET NULL, which never fires for a soft delete — the
     // defaults row keeps pointing at a category the UI no longer lists.

--- a/apps/web-next/e2e/tests/transaction-defaults.spec.ts
+++ b/apps/web-next/e2e/tests/transaction-defaults.spec.ts
@@ -1,0 +1,298 @@
+import { test, expect, type Page } from "@playwright/test";
+import {
+  createTestUser,
+  deleteTestUser,
+  loginUser,
+  seedReferenceDataForUser,
+  cleanupReferenceDataForUser,
+  selectFromVisibleAntdDropdown,
+  supabaseAdmin,
+} from "../utils/test-helpers";
+
+/**
+ * The whole antd Select for a given accessible name. The combobox role sits on
+ * the inner search input, whose immediate parent holds no text — the rendered
+ * selection lives further up, in the `.ant-select` shell.
+ */
+function selectShell(page: Page, comboboxName: string) {
+  return page
+    .getByRole("combobox", { name: comboboxName })
+    .locator(
+      "xpath=ancestor::div[contains(concat(' ', @class, ' '), ' ant-select ')][1]"
+    );
+}
+
+async function openTransactionsSettingsTab(page: Page) {
+  await page.goto("/settings");
+  await page.getByRole("tab", { name: /^transactions$/i }).click();
+  await expect(
+    page.getByRole("combobox", { name: "Default transaction type" })
+  ).toBeVisible();
+  // The grid renders before its category/bank-account options resolve; opening a
+  // Select mid-load yields an empty dropdown.
+  await expect(page.locator(".ant-spin-blur")).toHaveCount(0);
+}
+
+test.describe("Transaction Defaults", () => {
+  let testUser: { email: string; password: string; userId: string };
+
+  test.beforeAll(async () => {
+    testUser = await createTestUser("txn-defaults");
+    await seedReferenceDataForUser(testUser.userId);
+  });
+
+  test.afterAll(async () => {
+    await cleanupReferenceDataForUser(testUser.userId);
+    await deleteTestUser(testUser.userId);
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await supabaseAdmin
+      .from("user_transaction_defaults")
+      .delete()
+      .eq("user_id", testUser.userId);
+    await supabaseAdmin
+      .from("user_settings")
+      .update({ default_transaction_type: null })
+      .eq("user_id", testUser.userId);
+    await loginUser(page, testUser.email, testUser.password);
+  });
+
+  test("settings page exposes a Transactions tab with a row per type", async ({
+    page,
+  }) => {
+    await page.goto("/settings");
+
+    await expect(page.getByRole("tab")).toHaveCount(4);
+
+    await page.getByRole("tab", { name: /^transactions$/i }).click();
+
+    for (const label of ["Earn", "Spend", "Save"]) {
+      await expect(
+        page.getByRole("combobox", { name: `Default category for ${label}` })
+      ).toBeVisible();
+      await expect(
+        page.getByRole("combobox", {
+          name: `Default bank account for ${label}`,
+        })
+      ).toBeVisible();
+    }
+  });
+
+  test("category options are scoped to their row's transaction type", async ({
+    page,
+  }) => {
+    await openTransactionsSettingsTab(page);
+
+    // Seeded data has exactly one category per type: Groceries/spend,
+    // Salary/earn, Savings/save. The spend row must not offer the earn one.
+    await page
+      .getByRole("combobox", { name: "Default category for Spend" })
+      .click({ force: true });
+
+    const dropdown = page.locator(".ant-select-dropdown:visible");
+    await expect(dropdown.getByTitle(/^Groceries$/i)).toBeVisible();
+    await expect(dropdown.getByTitle(/^Salary$/i)).toHaveCount(0);
+  });
+
+  test("defaults persist across a reload", async ({ page }) => {
+    await openTransactionsSettingsTab(page);
+
+    await selectFromVisibleAntdDropdown(
+      page,
+      "Default transaction type",
+      "Spend"
+    );
+    await selectFromVisibleAntdDropdown(
+      page,
+      "Default category for Spend",
+      "Groceries"
+    );
+    await selectFromVisibleAntdDropdown(
+      page,
+      "Default bank account for Spend",
+      "Main Account"
+    );
+
+    // Each Select writes through on change, so there is no Save button to
+    // await. Reloading is the honest check that the value actually reached the
+    // database rather than only local state.
+    await page.reload();
+    await page.getByRole("tab", { name: /^transactions$/i }).click();
+
+    await expect(selectShell(page, "Default transaction type")).toContainText(
+      "Spend"
+    );
+    await expect(selectShell(page, "Default category for Spend")).toContainText(
+      "Groceries"
+    );
+    await expect(
+      selectShell(page, "Default bank account for Spend")
+    ).toContainText("Main Account");
+  });
+
+  test("a default can be cleared again", async ({ page }) => {
+    await openTransactionsSettingsTab(page);
+
+    await selectFromVisibleAntdDropdown(
+      page,
+      "Default category for Earn",
+      "Salary"
+    );
+
+    const shell = selectShell(page, "Default category for Earn");
+    await shell.hover();
+    await shell.locator(".ant-select-clear").click({ force: true });
+
+    await page.reload();
+    await page.getByRole("tab", { name: /^transactions$/i }).click();
+    await expect(
+      selectShell(page, "Default category for Earn")
+    ).not.toContainText("Salary");
+  });
+
+  test("create form pre-fills date, type, category and bank account", async ({
+    page,
+  }) => {
+    await openTransactionsSettingsTab(page);
+    await selectFromVisibleAntdDropdown(
+      page,
+      "Default transaction type",
+      "Spend"
+    );
+    await selectFromVisibleAntdDropdown(
+      page,
+      "Default category for Spend",
+      "Groceries"
+    );
+    await selectFromVisibleAntdDropdown(
+      page,
+      "Default bank account for Spend",
+      "Main Account"
+    );
+
+    // Reached directly, with no ?type= — the sidebar/kbar entry point, which is
+    // the case the stored default type exists to cover.
+    await page.goto("/transactions/create");
+
+    // DATE_PICKER_INPUT_FORMATS puts DD/MM/YYYY first, so that is what renders.
+    const today = new Date();
+    const expectedDate = `${String(today.getDate()).padStart(2, "0")}/${String(
+      today.getMonth() + 1
+    ).padStart(2, "0")}/${today.getFullYear()}`;
+    await expect(page.getByLabel("Date")).toHaveValue(expectedDate);
+
+    await expect(selectShell(page, "* Type")).toContainText(/spend/i);
+    await expect(selectShell(page, "* Category")).toContainText("Groceries");
+    await expect(selectShell(page, "* Bank Account")).toContainText(
+      "Main Account"
+    );
+  });
+
+  test("changing type on the create form swaps in that type's defaults", async ({
+    page,
+  }) => {
+    await openTransactionsSettingsTab(page);
+    await selectFromVisibleAntdDropdown(
+      page,
+      "Default category for Spend",
+      "Groceries"
+    );
+    await selectFromVisibleAntdDropdown(
+      page,
+      "Default bank account for Spend",
+      "Main Account"
+    );
+    await selectFromVisibleAntdDropdown(
+      page,
+      "Default category for Earn",
+      "Salary"
+    );
+    await selectFromVisibleAntdDropdown(
+      page,
+      "Default bank account for Earn",
+      "Secondary Account"
+    );
+
+    await page.goto("/transactions/create");
+
+    await selectFromVisibleAntdDropdown(page, "* Type", "Spend");
+    await expect(selectShell(page, "* Category")).toContainText("Groceries");
+    await expect(selectShell(page, "* Bank Account")).toContainText(
+      "Main Account"
+    );
+
+    await selectFromVisibleAntdDropdown(page, "* Type", "Earn");
+    await expect(selectShell(page, "* Category")).toContainText("Salary");
+    await expect(selectShell(page, "* Bank Account")).toContainText(
+      "Secondary Account"
+    );
+  });
+
+  test("a manually chosen bank account is not overwritten by the default", async ({
+    page,
+  }) => {
+    await openTransactionsSettingsTab(page);
+    await selectFromVisibleAntdDropdown(
+      page,
+      "Default transaction type",
+      "Spend"
+    );
+    await selectFromVisibleAntdDropdown(
+      page,
+      "Default bank account for Spend",
+      "Main Account"
+    );
+
+    await page.goto("/transactions/create");
+    await expect(selectShell(page, "* Bank Account")).toContainText(
+      "Main Account"
+    );
+
+    await selectFromVisibleAntdDropdown(
+      page,
+      "* Bank Account",
+      "Secondary Account"
+    );
+    await expect(selectShell(page, "* Bank Account")).toContainText(
+      "Secondary Account"
+    );
+  });
+
+  test("a soft-deleted default is ignored rather than shown as a raw id", async ({
+    page,
+  }) => {
+    await openTransactionsSettingsTab(page);
+    await selectFromVisibleAntdDropdown(
+      page,
+      "Default transaction type",
+      "Spend"
+    );
+    await selectFromVisibleAntdDropdown(
+      page,
+      "Default category for Spend",
+      "Groceries"
+    );
+
+    // The FK is ON DELETE SET NULL, which never fires for a soft delete — the
+    // defaults row keeps pointing at a category the UI no longer lists.
+    await supabaseAdmin
+      .from("categories")
+      .update({ deleted_at: new Date().toISOString() })
+      .eq("user_id", testUser.userId)
+      .eq("name", "Groceries");
+
+    await page.goto("/transactions/create");
+
+    const category = selectShell(page, "* Category");
+    await expect(category).not.toContainText("Groceries");
+    await expect(category).not.toContainText(/[0-9a-f]{8}-[0-9a-f]{4}/i);
+
+    // Restore for the remaining tests in the file
+    await supabaseAdmin
+      .from("categories")
+      .update({ deleted_at: null })
+      .eq("user_id", testUser.userId)
+      .eq("name", "Groceries");
+  });
+});

--- a/apps/web-next/e2e/tests/transactions-export.spec.ts
+++ b/apps/web-next/e2e/tests/transactions-export.spec.ts
@@ -304,4 +304,33 @@ test.describe("Transactions CSV Export", () => {
       page.getByText(/exceeds the 10,000-row export limit/i).first()
     ).toBeVisible();
   });
+
+  test("a range preset fills both dates and enables export", async ({
+    page,
+  }) => {
+    await page.goto("/settings");
+    await page.getByRole("tab", { name: /import.*export/i }).click();
+
+    const exportButton = page.getByRole("button", { name: /export csv/i });
+    await expect(exportButton).toBeDisabled();
+
+    await page.getByRole("textbox", { name: "Start date" }).click();
+    await page.getByText("Last month", { exact: true }).click();
+
+    const lastMonth = new Date();
+    lastMonth.setDate(1);
+    lastMonth.setMonth(lastMonth.getMonth() - 1);
+    const expectedMonth = `${String(lastMonth.getMonth() + 1).padStart(
+      2,
+      "0"
+    )}/${lastMonth.getFullYear()}`;
+
+    await expect(page.getByRole("textbox", { name: "Start date" })).toHaveValue(
+      `01/${expectedMonth}`
+    );
+    await expect(page.getByRole("textbox", { name: "End date" })).toHaveValue(
+      new RegExp(`^\\d{2}/${expectedMonth}$`)
+    );
+    await expect(exportButton).toBeEnabled();
+  });
 });

--- a/apps/web-next/src/contexts/currency/index.tsx
+++ b/apps/web-next/src/contexts/currency/index.tsx
@@ -6,7 +6,7 @@ import {
   useEffect,
   type PropsWithChildren,
 } from "react";
-import { supabaseClient } from "../../utility";
+import { supabaseClient, upsertUserSettings } from "../../utility";
 
 export const SUPPORTED_CURRENCIES = [
   { value: "GBP", label: "GBP — British Pound (£)" },
@@ -92,14 +92,11 @@ export const CurrencyContextProvider = ({ children }: PropsWithChildren) => {
 
     // Only persist to Supabase when authenticated; user_id set by DB trigger
     if (!currentUserIdRef.current) return;
-    supabaseClient
-      .from("user_settings")
-      .upsert({ currency: newCurrency }, { onConflict: "user_id" })
-      .then(({ error }) => {
-        if (error) {
-          console.error("[CurrencyContext] Failed to save currency:", error);
-        }
-      });
+    upsertUserSettings({ currency: newCurrency }).then(({ error }) => {
+      if (error) {
+        console.error("[CurrencyContext] Failed to save currency:", error);
+      }
+    });
   };
 
   return (

--- a/apps/web-next/src/hooks/index.ts
+++ b/apps/web-next/src/hooks/index.ts
@@ -12,3 +12,8 @@ export { useTransactionForm } from "./useTransactionForm";
 export type { TransactionFormValues } from "./useTransactionForm";
 export { useBudgetForm } from "./useBudgetForm";
 export type { BudgetFormValues } from "./useBudgetForm";
+export { useTransactionDefaults } from "./useTransactionDefaults";
+export type {
+  TransactionTypeDefaults,
+  TransactionDefaultsByType,
+} from "./useTransactionDefaults";

--- a/apps/web-next/src/hooks/useTransactionDefaults.ts
+++ b/apps/web-next/src/hooks/useTransactionDefaults.ts
@@ -1,0 +1,136 @@
+import { useCallback, useMemo } from "react";
+import { useInvalidate, useList, useNotification } from "@refinedev/core";
+import {
+  TRANSACTION_TYPES,
+  type TransactionType,
+} from "../constants/transactionTypes";
+import type { Database } from "../types/database.types";
+import { supabaseClient } from "../utility";
+
+type DefaultsRow =
+  Database["public"]["Tables"]["user_transaction_defaults"]["Row"];
+type UserSettingsRow = Database["public"]["Tables"]["user_settings"]["Row"];
+
+export interface TransactionTypeDefaults {
+  categoryId: string | null;
+  bankAccountId: string | null;
+}
+
+export type TransactionDefaultsByType = Record<
+  TransactionType,
+  TransactionTypeDefaults
+>;
+
+const EMPTY_DEFAULTS: TransactionTypeDefaults = {
+  categoryId: null,
+  bankAccountId: null,
+};
+
+function emptyDefaultsByType(): TransactionDefaultsByType {
+  return Object.values(TRANSACTION_TYPES).reduce((acc, type) => {
+    acc[type] = EMPTY_DEFAULTS;
+    return acc;
+  }, {} as TransactionDefaultsByType);
+}
+
+/**
+ * Reads and writes the user's transaction entry defaults: a category and bank
+ * account per transaction type, plus the type the Create form should open on.
+ *
+ * Writes go straight through supabaseClient rather than Refine mutations —
+ * user_transaction_defaults is keyed on the composite (user_id, type) and has no
+ * `id` column, which Refine's Supabase provider assumes. user_id is omitted from
+ * the payload deliberately: the set_user_id trigger fills it in server-side.
+ */
+export function useTransactionDefaults() {
+  const { open: openNotification } = useNotification();
+  const invalidate = useInvalidate();
+
+  const { result: defaultsResult, query: defaultsQuery } =
+    useList<DefaultsRow>({
+      resource: "user_transaction_defaults",
+      pagination: { mode: "off" },
+    });
+
+  const { result: settingsResult, query: settingsQuery } =
+    useList<UserSettingsRow>({
+      resource: "user_settings",
+      pagination: { mode: "off" },
+    });
+
+  const defaultsByType = useMemo(() => {
+    const byType = emptyDefaultsByType();
+    for (const row of defaultsResult?.data ?? []) {
+      byType[row.type] = {
+        categoryId: row.category_id,
+        bankAccountId: row.bank_account_id,
+      };
+    }
+    return byType;
+  }, [defaultsResult?.data]);
+
+  const defaultType = settingsResult?.data?.[0]?.default_transaction_type ?? null;
+
+  const notifyFailure = useCallback(
+    (message: string, description: string) => {
+      openNotification?.({ type: "error", message, description });
+    },
+    [openNotification]
+  );
+
+  const setDefaultsForType = useCallback(
+    async (type: TransactionType, next: TransactionTypeDefaults) => {
+      const { error } = await supabaseClient
+        .from("user_transaction_defaults")
+        .upsert(
+          {
+            type,
+            category_id: next.categoryId,
+            bank_account_id: next.bankAccountId,
+          },
+          { onConflict: "user_id,type" }
+        );
+
+      if (error) {
+        notifyFailure(
+          "Failed to save transaction defaults",
+          error.message
+        );
+        return;
+      }
+
+      await invalidate({
+        resource: "user_transaction_defaults",
+        invalidates: ["list"],
+      });
+    },
+    [invalidate, notifyFailure]
+  );
+
+  const setDefaultType = useCallback(
+    async (type: TransactionType | null) => {
+      const { error } = await supabaseClient
+        .from("user_settings")
+        .upsert(
+          { default_transaction_type: type },
+          { onConflict: "user_id" }
+        );
+
+      if (error) {
+        notifyFailure("Failed to save default type", error.message);
+        return;
+      }
+
+      await invalidate({ resource: "user_settings", invalidates: ["list"] });
+    },
+    [invalidate, notifyFailure]
+  );
+
+  return {
+    defaultsByType,
+    defaultType,
+    isLoading: defaultsQuery.isLoading || settingsQuery.isLoading,
+    setDefaultsForType,
+    setDefaultType,
+  };
+}

--- a/apps/web-next/src/hooks/useTransactionDefaults.ts
+++ b/apps/web-next/src/hooks/useTransactionDefaults.ts
@@ -5,7 +5,7 @@ import {
   type TransactionType,
 } from "../constants/transactionTypes";
 import type { Database } from "../types/database.types";
-import { supabaseClient } from "../utility";
+import { supabaseClient, upsertUserSettings } from "../utility";
 
 type DefaultsRow =
   Database["public"]["Tables"]["user_transaction_defaults"]["Row"];
@@ -79,17 +79,26 @@ export function useTransactionDefaults() {
   );
 
   const setDefaultsForType = useCallback(
-    async (type: TransactionType, next: TransactionTypeDefaults) => {
+    async (
+      type: TransactionType,
+      patch: Partial<TransactionTypeDefaults>
+    ) => {
+      // Only the changed column goes in the payload — PostgREST's upsert only
+      // SETs columns present in it, so this can't clobber the other column
+      // with a stale value from a defaultsByType snapshot that hasn't caught
+      // up with an in-flight write yet (defaultsByType only refreshes once
+      // invalidate()'s refetch below lands).
+      const row: { type: TransactionType } & Partial<{
+        category_id: string | null;
+        bank_account_id: string | null;
+      }> = { type };
+      if ("categoryId" in patch) row.category_id = patch.categoryId ?? null;
+      if ("bankAccountId" in patch)
+        row.bank_account_id = patch.bankAccountId ?? null;
+
       const { error } = await supabaseClient
         .from("user_transaction_defaults")
-        .upsert(
-          {
-            type,
-            category_id: next.categoryId,
-            bank_account_id: next.bankAccountId,
-          },
-          { onConflict: "user_id,type" }
-        );
+        .upsert(row, { onConflict: "user_id,type" });
 
       if (error) {
         notifyFailure(
@@ -109,12 +118,9 @@ export function useTransactionDefaults() {
 
   const setDefaultType = useCallback(
     async (type: TransactionType | null) => {
-      const { error } = await supabaseClient
-        .from("user_settings")
-        .upsert(
-          { default_transaction_type: type },
-          { onConflict: "user_id" }
-        );
+      const { error } = await upsertUserSettings({
+        default_transaction_type: type,
+      });
 
       if (error) {
         notifyFailure("Failed to save default type", error.message);

--- a/apps/web-next/src/pages/budgets/create.tsx
+++ b/apps/web-next/src/pages/budgets/create.tsx
@@ -2,10 +2,13 @@ import { useMemo } from "react";
 import { Create, useForm } from "@refinedev/antd";
 import { useList } from "@refinedev/core";
 import { Form, Input, InputNumber, Select, DatePicker } from "antd";
-import dayjs from "dayjs";
 import { TRANSACTION_TYPE_OPTIONS } from "../../constants/transactionTypes";
 import { useBudgetForm } from "../../hooks";
-import { DATE_PICKER_INPUT_FORMATS } from "../../utility";
+import {
+  DATE_PICKER_INPUT_FORMATS,
+  simpleLabelFilterOption,
+  toDayjs,
+} from "../../utility";
 import type { Category } from "../../utility/categoryHierarchy";
 import {
   categoryLabel,
@@ -79,9 +82,7 @@ export const BudgetCreate = () => {
         <Form.Item
           label="Start Date"
           name="start_date"
-          getValueProps={(value) => ({
-            value: value ? dayjs(value) : undefined,
-          })}
+          getValueProps={(value) => ({ value: toDayjs(value) })}
           getValueFromEvent={(date) => date?.format("YYYY-MM-DD")}
         >
           <DatePicker
@@ -92,9 +93,7 @@ export const BudgetCreate = () => {
         <Form.Item
           label="End Date"
           name="end_date"
-          getValueProps={(value) => ({
-            value: value ? dayjs(value) : undefined,
-          })}
+          getValueProps={(value) => ({ value: toDayjs(value) })}
           getValueFromEvent={(date) => date?.format("YYYY-MM-DD")}
         >
           <DatePicker
@@ -109,11 +108,7 @@ export const BudgetCreate = () => {
             loading={categoriesQuery.isLoading}
             placeholder="Select categories"
             showSearch
-            filterOption={(input, option) =>
-              (option?.label as string)
-                ?.toLowerCase()
-                .includes(input.toLowerCase())
-            }
+            filterOption={simpleLabelFilterOption}
             allowClear
           />
         </Form.Item>
@@ -124,11 +119,7 @@ export const BudgetCreate = () => {
             loading={tagsQuery.isLoading}
             placeholder="Select tags"
             showSearch
-            filterOption={(input, option) =>
-              (option?.label as string)
-                ?.toLowerCase()
-                .includes(input.toLowerCase())
-            }
+            filterOption={simpleLabelFilterOption}
             allowClear
           />
         </Form.Item>

--- a/apps/web-next/src/pages/budgets/edit.tsx
+++ b/apps/web-next/src/pages/budgets/edit.tsx
@@ -2,10 +2,13 @@ import { useEffect, useMemo } from "react";
 import { Edit, useForm } from "@refinedev/antd";
 import { useList } from "@refinedev/core";
 import { Form, Input, InputNumber, Select, DatePicker } from "antd";
-import dayjs from "dayjs";
 import { TRANSACTION_TYPE_OPTIONS } from "../../constants/transactionTypes";
 import { useBudgetForm } from "../../hooks";
-import { DATE_PICKER_INPUT_FORMATS } from "../../utility";
+import {
+  DATE_PICKER_INPUT_FORMATS,
+  simpleLabelFilterOption,
+  toDayjs,
+} from "../../utility";
 import type { Category } from "../../utility/categoryHierarchy";
 import {
   categoryLabel,
@@ -116,9 +119,7 @@ export const BudgetEdit = () => {
         <Form.Item
           label="Start Date"
           name="start_date"
-          getValueProps={(value) => ({
-            value: value ? dayjs(value) : undefined,
-          })}
+          getValueProps={(value) => ({ value: toDayjs(value) })}
           getValueFromEvent={(date) => date?.format("YYYY-MM-DD")}
         >
           <DatePicker
@@ -129,9 +130,7 @@ export const BudgetEdit = () => {
         <Form.Item
           label="End Date"
           name="end_date"
-          getValueProps={(value) => ({
-            value: value ? dayjs(value) : undefined,
-          })}
+          getValueProps={(value) => ({ value: toDayjs(value) })}
           getValueFromEvent={(date) => date?.format("YYYY-MM-DD")}
         >
           <DatePicker
@@ -146,11 +145,7 @@ export const BudgetEdit = () => {
             loading={categoriesQuery.isLoading}
             placeholder="Select categories"
             showSearch
-            filterOption={(input, option) =>
-              (option?.label as string)
-                ?.toLowerCase()
-                .includes(input.toLowerCase())
-            }
+            filterOption={simpleLabelFilterOption}
             allowClear
           />
         </Form.Item>
@@ -161,11 +156,7 @@ export const BudgetEdit = () => {
             loading={tagsQuery.isLoading}
             placeholder="Select tags"
             showSearch
-            filterOption={(input, option) =>
-              (option?.label as string)
-                ?.toLowerCase()
-                .includes(input.toLowerCase())
-            }
+            filterOption={simpleLabelFilterOption}
             allowClear
           />
         </Form.Item>

--- a/apps/web-next/src/pages/settings/index.tsx
+++ b/apps/web-next/src/pages/settings/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import {
   Card,
   Typography,
@@ -8,12 +8,13 @@ import {
   List,
   Space,
   Modal,
+  Table,
   Tabs,
   Select,
   DatePicker,
   Segmented,
 } from "antd";
-import { useNotification } from "@refinedev/core";
+import { useList, useNotification } from "@refinedev/core";
 import type { Dayjs } from "dayjs";
 import {
   UploadOutlined,
@@ -21,6 +22,7 @@ import {
   FileTextOutlined,
   GlobalOutlined,
   DownloadOutlined,
+  SlidersOutlined,
 } from "@ant-design/icons";
 import type { UploadFile, UploadProps } from "antd/es/upload/interface";
 import {
@@ -32,6 +34,7 @@ import {
   buildJsonExport,
   downloadJson,
   fetchTransactionsForExport,
+  getExportRangePresets,
   MAX_EXPORT_ROWS,
   DATE_PICKER_INPUT_FORMATS,
   type BulkUploadPayload,
@@ -41,6 +44,18 @@ import {
 import { Show } from "@refinedev/antd";
 import { useCurrency, SUPPORTED_CURRENCIES } from "../../contexts/currency";
 import { DANGER_BORDER_COLOR, DANGER_TEXT_COLOR } from "../../theme/tokens";
+import {
+  TRANSACTION_TYPES,
+  TRANSACTION_TYPE_LABELS,
+  TRANSACTION_TYPE_OPTIONS,
+  type TransactionType,
+} from "../../constants/transactionTypes";
+import { useTransactionDefaults } from "../../hooks";
+import type { Category, CategoryOption } from "../../utility/categoryHierarchy";
+import {
+  categoryFilterOption,
+  toLeafCategoryOptions,
+} from "../../utility/categoryHierarchy";
 
 const { Paragraph } = Typography;
 
@@ -297,6 +312,188 @@ const BulkUploadSection = () => {
   );
 };
 
+interface SelectOption {
+  label: string;
+  value: string;
+}
+
+/**
+ * A stored default can outlive its target: the FKs use ON DELETE SET NULL, which
+ * only fires on a hard delete, and this app soft-deletes. The `*_with_usage`
+ * views already exclude soft-deleted rows, so treating "not in options" as
+ * "no default" renders a stale reference as empty instead of a raw UUID.
+ */
+const valueIfStillAvailable = (
+  id: string | null,
+  options: readonly { value: string }[]
+): string | undefined =>
+  id && options.some((option) => option.value === id) ? id : undefined;
+
+/** A Select with a visually hidden label, so it has an accessible name. */
+const LabelledSelect = ({
+  id,
+  label,
+  ...selectProps
+}: {
+  id: string;
+  label: string;
+} & React.ComponentProps<typeof Select>) => (
+  <>
+    <label className="sr-only" htmlFor={id}>
+      {label}
+    </label>
+    <Select id={id} style={{ width: "100%", minWidth: 180 }} {...selectProps} />
+  </>
+);
+
+const TransactionDefaultsSection = () => {
+  const {
+    defaultsByType,
+    defaultType,
+    isLoading,
+    setDefaultsForType,
+    setDefaultType,
+  } = useTransactionDefaults();
+
+  // One fetch for all types, grouped client-side — cheaper than a query per row.
+  const { result: categoriesResult, query: categoriesQuery } = useList<Category>(
+    {
+      resource: "categories_with_usage",
+      pagination: { mode: "off" },
+      sorters: [{ field: "name", order: "asc" }],
+    }
+  );
+
+  const { result: bankAccountsResult, query: bankAccountsQuery } =
+    useList<{ id: string; name: string }>({
+      resource: "bank_accounts_with_usage",
+      pagination: { mode: "off" },
+      sorters: [{ field: "name", order: "asc" }],
+    });
+
+  const categoryOptionsByType = useMemo(() => {
+    const all = categoriesResult?.data ?? [];
+    return Object.values(TRANSACTION_TYPES).reduce(
+      (acc, type) => {
+        acc[type] = toLeafCategoryOptions(all.filter((c) => c.type === type));
+        return acc;
+      },
+      {} as Record<TransactionType, CategoryOption[]>
+    );
+  }, [categoriesResult?.data]);
+
+  const bankAccountOptions = useMemo<SelectOption[]>(
+    () =>
+      (bankAccountsResult?.data ?? []).map((account) => ({
+        label: account.name,
+        value: account.id,
+      })),
+    [bankAccountsResult?.data]
+  );
+
+  const optionsLoading = categoriesQuery.isLoading || bankAccountsQuery.isLoading;
+
+  return (
+    <Card title="Transaction Defaults" extra={<SlidersOutlined />}>
+      <Paragraph type="secondary">
+        Pre-fill the new transaction form. The default type decides which row's
+        category and bank account are applied; changing the type on the form
+        swaps them for that type's defaults.
+      </Paragraph>
+
+      <Space direction="vertical" style={{ width: "100%" }} size="middle">
+        <div>
+          <label className="sr-only" htmlFor="default-transaction-type">
+            Default transaction type
+          </label>
+          <Typography.Text strong>Default type</Typography.Text>
+          <Select
+            id="default-transaction-type"
+            style={{ width: 280, display: "block", marginTop: 8 }}
+            options={TRANSACTION_TYPE_OPTIONS}
+            value={defaultType ?? undefined}
+            onChange={(value) => setDefaultType((value ?? null) as TransactionType | null)}
+            placeholder="No default"
+            loading={isLoading}
+            allowClear
+          />
+        </div>
+
+        <Table
+          rowKey="type"
+          pagination={false}
+          loading={isLoading || optionsLoading}
+          scroll={{ x: "max-content" }}
+          dataSource={Object.values(TRANSACTION_TYPES).map((type) => ({
+            type,
+          }))}
+          columns={[
+            {
+              title: "Type",
+              dataIndex: "type",
+              render: (type: TransactionType) => TRANSACTION_TYPE_LABELS[type],
+            },
+            {
+              title: "Default Category",
+              key: "category",
+              render: (_, { type }) => (
+                <LabelledSelect
+                  id={`default-category-${type}`}
+                  label={`Default category for ${TRANSACTION_TYPE_LABELS[type]}`}
+                  options={categoryOptionsByType[type]}
+                  value={valueIfStillAvailable(
+                    defaultsByType[type].categoryId,
+                    categoryOptionsByType[type]
+                  )}
+                  onChange={(value) =>
+                    setDefaultsForType(type, {
+                      ...defaultsByType[type],
+                      categoryId: (value as string | undefined) ?? null,
+                    })
+                  }
+                  placeholder="No default"
+                  showSearch
+                  filterOption={categoryFilterOption}
+                  allowClear
+                />
+              ),
+            },
+            {
+              title: "Default Bank Account",
+              key: "bank_account",
+              render: (_, { type }) => (
+                <LabelledSelect
+                  id={`default-bank-account-${type}`}
+                  label={`Default bank account for ${TRANSACTION_TYPE_LABELS[type]}`}
+                  options={bankAccountOptions}
+                  value={valueIfStillAvailable(
+                    defaultsByType[type].bankAccountId,
+                    bankAccountOptions
+                  )}
+                  onChange={(value) =>
+                    setDefaultsForType(type, {
+                      ...defaultsByType[type],
+                      bankAccountId: (value as string | undefined) ?? null,
+                    })
+                  }
+                  placeholder="No default"
+                  showSearch
+                  filterOption={(input, option) =>
+                    String(option?.label ?? "")
+                      .toLowerCase()
+                      .includes(input.toLowerCase())
+                  }
+                  allowClear
+                />
+              ),
+            },
+          ]}
+        />
+      </Space>
+    </Card>
+  );
+};
+
 type ExportFormat = "csv" | "json";
 
 const ExportSection = () => {
@@ -372,6 +569,7 @@ const ExportSection = () => {
         />
         <DatePicker.RangePicker
           format={DATE_PICKER_INPUT_FORMATS}
+          presets={getExportRangePresets()}
           value={range}
           onChange={(dates) =>
             setRange(dates && dates[0] && dates[1] ? [dates[0], dates[1]] : null)
@@ -552,6 +750,11 @@ export const SettingsPage = () => {
             key: "general",
             label: "General",
             children: <CurrencySection />,
+          },
+          {
+            key: "transactions",
+            label: "Transactions",
+            children: <TransactionDefaultsSection />,
           },
           {
             key: "import-export",

--- a/apps/web-next/src/pages/settings/index.tsx
+++ b/apps/web-next/src/pages/settings/index.tsx
@@ -36,6 +36,7 @@ import {
   fetchTransactionsForExport,
   getExportRangePresets,
   simpleLabelFilterOption,
+  valueIfStillAvailable,
   MAX_EXPORT_ROWS,
   DATE_PICKER_INPUT_FORMATS,
   type BulkUploadPayload,
@@ -318,33 +319,33 @@ interface SelectOption {
   value: string;
 }
 
-/**
- * A stored default can outlive its target: the FKs use ON DELETE SET NULL, which
- * only fires on a hard delete, and this app soft-deletes. The `*_with_usage`
- * views already exclude soft-deleted rows, so treating "not in options" as
- * "no default" renders a stale reference as empty instead of a raw UUID.
- */
-const valueIfStillAvailable = (
-  id: string | null,
-  options: readonly { value: string }[]
-): string | undefined =>
-  id && options.some((option) => option.value === id) ? id : undefined;
-
-/** A Select with a visually hidden label, so it has an accessible name. */
-const LabelledSelect = ({
-  id,
-  label,
-  ...selectProps
+/** One editable cell in the defaults grid: a per-type default id, backed by a
+ * select whose options and filter strategy vary by field (category vs. bank
+ * account) but whose value/change/stale-guard wiring is otherwise identical. */
+const DefaultValueSelect = ({
+  ariaLabel,
+  options,
+  value,
+  onChange,
+  filterOption,
 }: {
-  id: string;
-  label: string;
-} & React.ComponentProps<typeof Select>) => (
-  <>
-    <label className="sr-only" htmlFor={id}>
-      {label}
-    </label>
-    <Select id={id} style={{ width: "100%", minWidth: 180 }} {...selectProps} />
-  </>
+  ariaLabel: string;
+  options: SelectOption[];
+  value: string | null;
+  onChange: (value: string | null) => void;
+  filterOption: React.ComponentProps<typeof Select>["filterOption"];
+}) => (
+  <Select
+    aria-label={ariaLabel}
+    style={{ width: "100%", minWidth: 180 }}
+    options={options}
+    value={valueIfStillAvailable(value, options)}
+    onChange={(next) => onChange((next as string | undefined) ?? null)}
+    placeholder="No default"
+    showSearch
+    filterOption={filterOption}
+    allowClear
+  />
 );
 
 const TransactionDefaultsSection = () => {
@@ -404,12 +405,9 @@ const TransactionDefaultsSection = () => {
 
       <Space direction="vertical" style={{ width: "100%" }} size="middle">
         <div>
-          <label className="sr-only" htmlFor="default-transaction-type">
-            Default transaction type
-          </label>
           <Typography.Text strong>Default type</Typography.Text>
           <Select
-            id="default-transaction-type"
+            aria-label="Default transaction type"
             style={{ width: 280, display: "block", marginTop: 8 }}
             options={TRANSACTION_TYPE_OPTIONS}
             value={defaultType ?? undefined}
@@ -438,23 +436,12 @@ const TransactionDefaultsSection = () => {
               title: "Default Category",
               key: "category",
               render: (_, { type }) => (
-                <LabelledSelect
-                  id={`default-category-${type}`}
-                  label={`Default category for ${TRANSACTION_TYPE_LABELS[type]}`}
+                <DefaultValueSelect
+                  ariaLabel={`Default category for ${TRANSACTION_TYPE_LABELS[type]}`}
                   options={categoryOptionsByType[type]}
-                  value={valueIfStillAvailable(
-                    defaultsByType[type].categoryId,
-                    categoryOptionsByType[type]
-                  )}
-                  onChange={(value) =>
-                    setDefaultsForType(type, {
-                      categoryId: (value as string | undefined) ?? null,
-                    })
-                  }
-                  placeholder="No default"
-                  showSearch
+                  value={defaultsByType[type].categoryId}
+                  onChange={(categoryId) => setDefaultsForType(type, { categoryId })}
                   filterOption={categoryFilterOption}
-                  allowClear
                 />
               ),
             },
@@ -462,23 +449,14 @@ const TransactionDefaultsSection = () => {
               title: "Default Bank Account",
               key: "bank_account",
               render: (_, { type }) => (
-                <LabelledSelect
-                  id={`default-bank-account-${type}`}
-                  label={`Default bank account for ${TRANSACTION_TYPE_LABELS[type]}`}
+                <DefaultValueSelect
+                  ariaLabel={`Default bank account for ${TRANSACTION_TYPE_LABELS[type]}`}
                   options={bankAccountOptions}
-                  value={valueIfStillAvailable(
-                    defaultsByType[type].bankAccountId,
-                    bankAccountOptions
-                  )}
-                  onChange={(value) =>
-                    setDefaultsForType(type, {
-                      bankAccountId: (value as string | undefined) ?? null,
-                    })
+                  value={defaultsByType[type].bankAccountId}
+                  onChange={(bankAccountId) =>
+                    setDefaultsForType(type, { bankAccountId })
                   }
-                  placeholder="No default"
-                  showSearch
                   filterOption={simpleLabelFilterOption}
-                  allowClear
                 />
               ),
             },
@@ -497,6 +475,10 @@ const ExportSection = () => {
   const [format, setFormat] = useState<ExportFormat>("csv");
   const [isExporting, setIsExporting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Evaluated once per mount, not per render — still fresh on every visit to
+  // the page (unlike a module-level constant), without recomputing on every
+  // keystroke/toggle elsewhere in this component.
+  const rangePresets = useMemo(() => getExportRangePresets(), []);
 
   const handleExport = async () => {
     if (!range) {
@@ -564,7 +546,7 @@ const ExportSection = () => {
         />
         <DatePicker.RangePicker
           format={DATE_PICKER_INPUT_FORMATS}
-          presets={getExportRangePresets()}
+          presets={rangePresets}
           value={range}
           onChange={(dates) =>
             setRange(dates && dates[0] && dates[1] ? [dates[0], dates[1]] : null)

--- a/apps/web-next/src/pages/settings/index.tsx
+++ b/apps/web-next/src/pages/settings/index.tsx
@@ -35,6 +35,7 @@ import {
   downloadJson,
   fetchTransactionsForExport,
   getExportRangePresets,
+  simpleLabelFilterOption,
   MAX_EXPORT_ROWS,
   DATE_PICKER_INPUT_FORMATS,
   type BulkUploadPayload,
@@ -447,7 +448,6 @@ const TransactionDefaultsSection = () => {
                   )}
                   onChange={(value) =>
                     setDefaultsForType(type, {
-                      ...defaultsByType[type],
                       categoryId: (value as string | undefined) ?? null,
                     })
                   }
@@ -472,17 +472,12 @@ const TransactionDefaultsSection = () => {
                   )}
                   onChange={(value) =>
                     setDefaultsForType(type, {
-                      ...defaultsByType[type],
                       bankAccountId: (value as string | undefined) ?? null,
                     })
                   }
                   placeholder="No default"
                   showSearch
-                  filterOption={(input, option) =>
-                    String(option?.label ?? "")
-                      .toLowerCase()
-                      .includes(input.toLowerCase())
-                  }
+                  filterOption={simpleLabelFilterOption}
                   allowClear
                 />
               ),

--- a/apps/web-next/src/pages/transactions/create.tsx
+++ b/apps/web-next/src/pages/transactions/create.tsx
@@ -14,6 +14,7 @@ import {
   DATE_PICKER_INPUT_FORMATS,
   simpleLabelFilterOption,
   toDayjs,
+  valueIfStillAvailable,
 } from "../../utility";
 import type { Category } from "../../utility/categoryHierarchy";
 import {
@@ -52,10 +53,7 @@ export const TransactionCreate = () => {
   // antd re-seed the fields from it, which silently discards a date the user is
   // part-way through typing. Type is deliberately not in here — it can arrive
   // asynchronously with the stored default, so the effect below applies it.
-  const [initialValues] = useState(() => ({
-    ...(formProps.initialValues ?? {}),
-    date: dayjs(),
-  }));
+  const [initialValues] = useState(() => ({ date: dayjs() }));
 
   const type = Form.useWatch("type", formProps.form);
 
@@ -105,23 +103,22 @@ export const TransactionCreate = () => {
     const defaults = defaultsByType[type as TransactionType];
     if (!defaults) return;
 
-    if (
-      !form.getFieldValue("category_id") &&
-      defaults.categoryId &&
-      leafCategoryOptions.some((o) => o.value === defaults.categoryId)
-    ) {
-      form.setFieldValue("category_id", defaults.categoryId);
-    }
+    const applyDefaultIfEmpty = (
+      field: string,
+      defaultId: string | null,
+      options: readonly { value?: unknown }[]
+    ) => {
+      if (form.getFieldValue(field)) return;
+      const value = valueIfStillAvailable(defaultId, options);
+      if (value) form.setFieldValue(field, value);
+    };
 
-    if (
-      !form.getFieldValue("bank_account_id") &&
-      defaults.bankAccountId &&
-      (bankAccountSelectProps.options ?? []).some(
-        (o) => String(o.value) === defaults.bankAccountId
-      )
-    ) {
-      form.setFieldValue("bank_account_id", defaults.bankAccountId);
-    }
+    applyDefaultIfEmpty("category_id", defaults.categoryId, leafCategoryOptions);
+    applyDefaultIfEmpty(
+      "bank_account_id",
+      defaults.bankAccountId,
+      bankAccountSelectProps.options ?? []
+    );
   }, [
     type,
     defaultsByType,

--- a/apps/web-next/src/pages/transactions/create.tsx
+++ b/apps/web-next/src/pages/transactions/create.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Create, useForm, useSelect as useAntSelect } from "@refinedev/antd";
 import { useSelect as useCoreSelect, useList } from "@refinedev/core";
 import { Form, DatePicker, Select, InputNumber, Input } from "antd";
@@ -9,14 +9,12 @@ import {
   TRANSACTION_TYPE_OPTIONS,
   type TransactionType,
 } from "../../constants/transactionTypes";
-import { useTransactionForm } from "../../hooks";
-import { DATE_PICKER_INPUT_FORMATS } from "../../utility";
+import { useTransactionDefaults, useTransactionForm } from "../../hooks";
+import { DATE_PICKER_INPUT_FORMATS, toDayjs } from "../../utility";
 import type { Category } from "../../utility/categoryHierarchy";
 import {
-  categoryLabel,
-  categorySearchText,
-  compareCategoriesByHierarchyLabel,
-  isLeafCategory,
+  categoryFilterOption,
+  toLeafCategoryOptions,
 } from "../../utility/categoryHierarchy";
 
 const VALID_TRANSACTION_TYPES = new Set<TransactionType>(
@@ -25,7 +23,7 @@ const VALID_TRANSACTION_TYPES = new Set<TransactionType>(
 
 export const TransactionCreate = () => {
   const [searchParams] = useSearchParams();
-  const initialType = useMemo<TransactionType | undefined>(() => {
+  const typeFromUrl = useMemo<TransactionType | undefined>(() => {
     const source = searchParams.get("source");
     const rawType = searchParams.get("type");
 
@@ -40,22 +38,28 @@ export const TransactionCreate = () => {
     warnWhenUnsavedChanges: false,
   });
   const { handleFinish, isLoading } = useTransactionForm({ mode: "create" });
-  const mergedInitialValues = useMemo(() => {
-    const existingInitialValues = formProps.initialValues ?? {};
+  const { defaultsByType, defaultType } = useTransactionDefaults();
 
-    if (!initialType) {
-      return Object.keys(existingInitialValues).length
-        ? existingInitialValues
-        : undefined;
-    }
+  // The URL wins over the stored default: arriving from a typed list tab is an
+  // explicit choice, the stored default is only a fallback.
+  const initialType = typeFromUrl ?? defaultType ?? undefined;
 
-    return {
-      ...existingInitialValues,
-      type: initialType,
-    };
-  }, [formProps.initialValues, initialType]);
+  // Frozen at mount. A fresh object (or a fresh dayjs()) on later renders makes
+  // antd re-seed the fields from it, which silently discards a date the user is
+  // part-way through typing. Type is deliberately not in here — it can arrive
+  // asynchronously with the stored default, so the effect below applies it.
+  const [initialValues] = useState(() => ({
+    ...(formProps.initialValues ?? {}),
+    date: dayjs(),
+  }));
 
   const type = Form.useWatch("type", formProps.form);
+
+  useEffect(() => {
+    if (!initialType || !formProps.form) return;
+    if (formProps.form.getFieldValue("type")) return;
+    formProps.form.setFieldValue("type", initialType);
+  }, [initialType, formProps.form]);
 
   const { result: categoriesResult } = useList<Category>({
     resource: "categories_with_usage",
@@ -65,14 +69,10 @@ export const TransactionCreate = () => {
     queryOptions: { enabled: !!type },
   });
 
-  const leafCategoryOptions = (categoriesResult?.data ?? [])
-    .filter(isLeafCategory)
-    .sort(compareCategoriesByHierarchyLabel)
-    .map((c: Category) => ({
-      label: categoryLabel(c),
-      value: c.id,
-      searchText: categorySearchText(c),
-    }));
+  const leafCategoryOptions = useMemo(
+    () => toLeafCategoryOptions(categoriesResult?.data ?? []),
+    [categoriesResult?.data]
+  );
 
   const { options: tagOptions, query: tagsQuery } = useCoreSelect({
     resource: "tags_with_usage",
@@ -89,11 +89,48 @@ export const TransactionCreate = () => {
     sorters: [{ field: "name", order: "asc" }],
   });
 
+  // Apply this type's defaults once the matching options have loaded, and only
+  // into fields that are still empty — so this never overwrites a user's pick.
+  // Only ids present in the loaded options are used: the views exclude
+  // soft-deleted rows, so a stale default is silently skipped rather than
+  // written back as an unresolvable value.
+  useEffect(() => {
+    const form = formProps.form;
+    if (!form || !type) return;
+
+    const defaults = defaultsByType[type as TransactionType];
+    if (!defaults) return;
+
+    if (
+      !form.getFieldValue("category_id") &&
+      defaults.categoryId &&
+      leafCategoryOptions.some((o) => o.value === defaults.categoryId)
+    ) {
+      form.setFieldValue("category_id", defaults.categoryId);
+    }
+
+    if (
+      !form.getFieldValue("bank_account_id") &&
+      defaults.bankAccountId &&
+      (bankAccountSelectProps.options ?? []).some(
+        (o) => String(o.value) === defaults.bankAccountId
+      )
+    ) {
+      form.setFieldValue("bank_account_id", defaults.bankAccountId);
+    }
+  }, [
+    type,
+    defaultsByType,
+    leafCategoryOptions,
+    bankAccountSelectProps.options,
+    formProps.form,
+  ]);
+
   return (
     <Create saveButtonProps={{ ...saveButtonProps, loading: isLoading }}>
       <Form
         {...formProps}
-        initialValues={mergedInitialValues}
+        initialValues={initialValues}
         layout="vertical"
         onFinish={handleFinish}
       >
@@ -101,18 +138,22 @@ export const TransactionCreate = () => {
           label="Date"
           name={["date"]}
           rules={[{ required: true }]}
-          getValueProps={(value) => ({
-            value: value ? dayjs(value) : undefined,
-          })}
+          getValueProps={(value) => ({ value: toDayjs(value) })}
         >
           <DatePicker format={DATE_PICKER_INPUT_FORMATS} />
         </Form.Item>
         <Form.Item label="Type" name={["type"]} rules={[{ required: true }]}>
           <Select
             options={TRANSACTION_TYPE_OPTIONS}
-            onChange={() =>
-              formProps.form?.setFieldValue("category_id", undefined)
-            }
+            onChange={() => {
+              // Categories are type-specific, and the bank account default is
+              // per-type too — clear both so the effect above refills them from
+              // the newly selected type's defaults.
+              formProps.form?.setFieldsValue({
+                category_id: undefined,
+                bank_account_id: undefined,
+              });
+            }}
           />
         </Form.Item>
         <Form.Item
@@ -123,20 +164,7 @@ export const TransactionCreate = () => {
           <Select
             options={leafCategoryOptions}
             showSearch
-            filterOption={(input, option) => {
-              const normalized = input.toLowerCase();
-              const label = String(option?.label ?? "").toLowerCase();
-              const searchText =
-                option &&
-                typeof option === "object" &&
-                "searchText" in option &&
-                typeof option.searchText === "string"
-                  ? option.searchText
-                  : "";
-              return (
-                label.includes(normalized) || searchText.includes(normalized)
-              );
-            }}
+            filterOption={categoryFilterOption}
           />
         </Form.Item>
         <Form.Item

--- a/apps/web-next/src/pages/transactions/create.tsx
+++ b/apps/web-next/src/pages/transactions/create.tsx
@@ -10,7 +10,11 @@ import {
   type TransactionType,
 } from "../../constants/transactionTypes";
 import { useTransactionDefaults, useTransactionForm } from "../../hooks";
-import { DATE_PICKER_INPUT_FORMATS, toDayjs } from "../../utility";
+import {
+  DATE_PICKER_INPUT_FORMATS,
+  simpleLabelFilterOption,
+  toDayjs,
+} from "../../utility";
 import type { Category } from "../../utility/categoryHierarchy";
 import {
   categoryFilterOption,
@@ -196,11 +200,7 @@ export const TransactionCreate = () => {
             loading={tagsQuery.isLoading}
             placeholder="Select tags"
             showSearch
-            filterOption={(input, option) =>
-              (option?.label as string)
-                ?.toLowerCase()
-                .includes(input.toLowerCase())
-            }
+            filterOption={simpleLabelFilterOption}
             allowClear
           />
         </Form.Item>

--- a/apps/web-next/src/pages/transactions/edit.tsx
+++ b/apps/web-next/src/pages/transactions/edit.tsx
@@ -7,7 +7,11 @@ import {
   TransactionType,
 } from "../../constants/transactionTypes";
 import { useTransactionForm } from "../../hooks";
-import { DATE_PICKER_INPUT_FORMATS, toDayjs } from "../../utility";
+import {
+  DATE_PICKER_INPUT_FORMATS,
+  simpleLabelFilterOption,
+  toDayjs,
+} from "../../utility";
 import type { Category } from "../../utility/categoryHierarchy";
 import {
   categoryFilterOption,
@@ -189,11 +193,7 @@ export const TransactionEdit = () => {
             loading={tagsQuery.isLoading}
             placeholder="Select tags"
             showSearch
-            filterOption={(input, option) =>
-              (option?.label as string)
-                ?.toLowerCase()
-                .includes(input.toLowerCase())
-            }
+            filterOption={simpleLabelFilterOption}
             allowClear
           />
         </Form.Item>

--- a/apps/web-next/src/pages/transactions/edit.tsx
+++ b/apps/web-next/src/pages/transactions/edit.tsx
@@ -2,19 +2,18 @@ import { useEffect, useMemo } from "react";
 import { Edit, useForm, useSelect as useAntSelect } from "@refinedev/antd";
 import { useSelect as useCoreSelect, useList } from "@refinedev/core";
 import { Form, DatePicker, Select, InputNumber, Input } from "antd";
-import dayjs from "dayjs";
 import {
   TRANSACTION_TYPE_OPTIONS,
   TransactionType,
 } from "../../constants/transactionTypes";
 import { useTransactionForm } from "../../hooks";
-import { DATE_PICKER_INPUT_FORMATS } from "../../utility";
+import { DATE_PICKER_INPUT_FORMATS, toDayjs } from "../../utility";
 import type { Category } from "../../utility/categoryHierarchy";
 import {
+  categoryFilterOption,
   categoryLabel as formatCategoryLabel,
   categorySearchText as getCategorySearchText,
-  compareCategoriesByHierarchyLabel,
-  isLeafCategory,
+  toLeafCategoryOptions,
 } from "../../utility/categoryHierarchy";
 
 export const TransactionEdit = () => {
@@ -60,14 +59,7 @@ export const TransactionEdit = () => {
 
   const leafCategoryOptions = useMemo(() => {
     const all = categoriesResult?.data ?? [];
-    const leaves = all
-      .filter(isLeafCategory)
-      .sort(compareCategoriesByHierarchyLabel)
-      .map((c: Category) => ({
-        label: formatCategoryLabel(c),
-        value: c.id,
-        searchText: getCategorySearchText(c),
-      }));
+    const leaves = toLeafCategoryOptions(all);
     // Always include the current category even if it has since become a parent,
     // so the form doesn't show a raw UUID or blank value.
     if (
@@ -127,9 +119,7 @@ export const TransactionEdit = () => {
               required: true,
             },
           ]}
-          getValueProps={(value) => ({
-            value: value ? dayjs(value) : undefined,
-          })}
+          getValueProps={(value) => ({ value: toDayjs(value) })}
         >
           <DatePicker format={DATE_PICKER_INPUT_FORMATS} />
         </Form.Item>
@@ -163,20 +153,7 @@ export const TransactionEdit = () => {
             options={leafCategoryOptions}
             loading={categoriesQuery.isLoading}
             showSearch
-            filterOption={(input, option) => {
-              const normalized = input.toLowerCase();
-              const label = String(option?.label ?? "").toLowerCase();
-              const searchText =
-                option &&
-                typeof option === "object" &&
-                "searchText" in option &&
-                typeof option.searchText === "string"
-                  ? option.searchText
-                  : "";
-              return (
-                label.includes(normalized) || searchText.includes(normalized)
-              );
-            }}
+            filterOption={categoryFilterOption}
           />
         </Form.Item>
         <Form.Item

--- a/apps/web-next/src/styles/global.css
+++ b/apps/web-next/src/styles/global.css
@@ -53,3 +53,20 @@ h6 {
 * {
   box-sizing: border-box;
 }
+
+/*
+ * Visually hidden but still announced by screen readers and still resolvable as
+ * an accessible name. Used for labels on controls whose meaning is carried
+ * visually by a surrounding table header.
+ */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/apps/web-next/src/styles/global.css
+++ b/apps/web-next/src/styles/global.css
@@ -53,20 +53,3 @@ h6 {
 * {
   box-sizing: border-box;
 }
-
-/*
- * Visually hidden but still announced by screen readers and still resolvable as
- * an accessible name. Used for labels on controls whose meaning is carried
- * visually by a surrounding table header.
- */
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}

--- a/apps/web-next/src/types/database.types.ts
+++ b/apps/web-next/src/types/database.types.ts
@@ -489,22 +489,87 @@ export type Database = {
         Row: {
           created_at: string;
           currency: string;
+          default_transaction_type:
+            | Database["public"]["Enums"]["transaction_type"]
+            | null;
           updated_at: string;
           user_id: string;
         };
         Insert: {
           created_at?: string;
           currency?: string;
+          default_transaction_type?:
+            | Database["public"]["Enums"]["transaction_type"]
+            | null;
           updated_at?: string;
           user_id: string;
         };
         Update: {
           created_at?: string;
           currency?: string;
+          default_transaction_type?:
+            | Database["public"]["Enums"]["transaction_type"]
+            | null;
           updated_at?: string;
           user_id?: string;
         };
         Relationships: [];
+      };
+      user_transaction_defaults: {
+        Row: {
+          bank_account_id: string | null;
+          category_id: string | null;
+          created_at: string;
+          type: Database["public"]["Enums"]["transaction_type"];
+          updated_at: string;
+          user_id: string;
+        };
+        Insert: {
+          bank_account_id?: string | null;
+          category_id?: string | null;
+          created_at?: string;
+          type: Database["public"]["Enums"]["transaction_type"];
+          updated_at?: string;
+          user_id: string;
+        };
+        Update: {
+          bank_account_id?: string | null;
+          category_id?: string | null;
+          created_at?: string;
+          type?: Database["public"]["Enums"]["transaction_type"];
+          updated_at?: string;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "user_transaction_defaults_bank_account_id_fkey";
+            columns: ["bank_account_id"];
+            isOneToOne: false;
+            referencedRelation: "bank_accounts";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "user_transaction_defaults_bank_account_id_fkey";
+            columns: ["bank_account_id"];
+            isOneToOne: false;
+            referencedRelation: "bank_accounts_with_usage";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "user_transaction_defaults_category_id_fkey";
+            columns: ["category_id"];
+            isOneToOne: false;
+            referencedRelation: "categories";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "user_transaction_defaults_category_id_fkey";
+            columns: ["category_id"];
+            isOneToOne: false;
+            referencedRelation: "categories_with_usage";
+            referencedColumns: ["id"];
+          },
+        ];
       };
     };
     Views: {

--- a/apps/web-next/src/utility/categoryHierarchy.ts
+++ b/apps/web-next/src/utility/categoryHierarchy.ts
@@ -1,3 +1,4 @@
+import type { DefaultOptionType } from "antd/es/select";
 import type { Tables } from "../types/database.types";
 
 export type Category = Tables<"categories"> & {
@@ -50,4 +51,42 @@ export const compareCategoriesByHierarchyLabel = (
   );
   if (primary !== 0) return primary;
   return String(a.id).localeCompare(String(b.id));
+};
+
+export interface CategoryOption {
+  label: string;
+  value: string;
+  searchText: string;
+}
+
+/**
+ * Leaf categories as antd Select options, ordered by hierarchy label. Every
+ * category picker in the app shows the same thing, so they all build options
+ * through here rather than repeating the filter/sort/map.
+ */
+export const toLeafCategoryOptions = (
+  categories: Category[]
+): CategoryOption[] =>
+  leafCategoriesOnly(categories)
+    .sort(compareCategoriesByHierarchyLabel)
+    .map((category) => ({
+      label: categoryLabel(category),
+      value: category.id,
+      searchText: categorySearchText(category),
+    }));
+
+/**
+ * antd `filterOption` for category selects: matches against the visible label
+ * *and* the parent-inclusive search text, so typing a parent name surfaces its
+ * children even though the label starts with the parent.
+ */
+export const categoryFilterOption = (
+  input: string,
+  option?: DefaultOptionType
+): boolean => {
+  const normalized = input.toLowerCase();
+  const label = String(option?.label ?? "").toLowerCase();
+  const searchText =
+    typeof option?.searchText === "string" ? option.searchText : "";
+  return label.includes(normalized) || searchText.includes(normalized);
 };

--- a/apps/web-next/src/utility/dateRanges.ts
+++ b/apps/web-next/src/utility/dateRanges.ts
@@ -1,4 +1,4 @@
-import dayjs from "dayjs";
+import dayjs, { type Dayjs } from "dayjs";
 
 export function getPreviousPeriodRange(
   period: "month" | "year",
@@ -10,4 +10,49 @@ export function getPreviousPeriodRange(
     prevStart: dayjs(startDate).subtract(1, unit).format("YYYY-MM-DD"),
     prevEnd: dayjs(endDate).subtract(1, unit).format("YYYY-MM-DD"),
   };
+}
+
+export interface DateRangePreset {
+  label: string;
+  value: [Dayjs, Dayjs];
+}
+
+/**
+ * Shortcut ranges for the export RangePicker.
+ *
+ * Deliberately a function rather than a module-level constant: the ranges are
+ * anchored to "now", and a constant would freeze that at module load and go
+ * stale in a long-lived tab (see `constants/dateOptions.ts` for that bug).
+ */
+export function getExportRangePresets(): DateRangePreset[] {
+  const today = dayjs();
+  const lastMonth = today.subtract(1, "month");
+  const lastYear = today.subtract(1, "year");
+
+  return [
+    {
+      label: "This month",
+      value: [today.startOf("month"), today.endOf("month")],
+    },
+    {
+      label: "Last month",
+      value: [lastMonth.startOf("month"), lastMonth.endOf("month")],
+    },
+    {
+      label: "Last 3 months",
+      value: [today.subtract(2, "month").startOf("month"), today.endOf("month")],
+    },
+    {
+      label: "Last 12 months",
+      value: [today.subtract(11, "month").startOf("month"), today.endOf("month")],
+    },
+    {
+      label: "This year",
+      value: [today.startOf("year"), today.endOf("year")],
+    },
+    {
+      label: "Last year",
+      value: [lastYear.startOf("year"), lastYear.endOf("year")],
+    },
+  ];
 }

--- a/apps/web-next/src/utility/dateRanges.ts
+++ b/apps/web-next/src/utility/dateRanges.ts
@@ -39,12 +39,20 @@ export function getExportRangePresets(): DateRangePreset[] {
       value: [lastMonth.startOf("month"), lastMonth.endOf("month")],
     },
     {
+      // The 3/12 complete calendar months before the current one — consistent
+      // with "Last month"/"Last year" excluding the current, incomplete period.
       label: "Last 3 months",
-      value: [today.subtract(2, "month").startOf("month"), today.endOf("month")],
+      value: [
+        today.subtract(3, "month").startOf("month"),
+        lastMonth.endOf("month"),
+      ],
     },
     {
       label: "Last 12 months",
-      value: [today.subtract(11, "month").startOf("month"), today.endOf("month")],
+      value: [
+        today.subtract(12, "month").startOf("month"),
+        lastMonth.endOf("month"),
+      ],
     },
     {
       label: "This year",

--- a/apps/web-next/src/utility/dayjsValue.ts
+++ b/apps/web-next/src/utility/dayjsValue.ts
@@ -1,0 +1,17 @@
+import dayjs, { type Dayjs } from "dayjs";
+
+/**
+ * Normalises a stored form value into what antd's DatePicker wants, **without**
+ * rewrapping a value that is already a Dayjs.
+ *
+ * The naive `dayjs(value)` returns a new instance on every render. rc-picker
+ * treats a new `value` identity as an external change and throws away whatever
+ * the user is part-way through typing — so on a form with any background query
+ * still resolving, a typed date silently reverts. Returning the same instance
+ * when nothing changed keeps typing stable.
+ */
+export const toDayjs = (value: unknown): Dayjs | undefined => {
+  if (!value) return undefined;
+  if (dayjs.isDayjs(value)) return value;
+  return dayjs(value as string | number | Date);
+};

--- a/apps/web-next/src/utility/index.ts
+++ b/apps/web-next/src/utility/index.ts
@@ -5,6 +5,8 @@ export * from "./rpc";
 export * from "./dateDisplay";
 export * from "./dateRanges";
 export * from "./dayjsValue";
+export * from "./selectFilterOption";
+export * from "./userSettings";
 export * from "./datePickerFormats";
 export * from "./csvExport";
 export * from "./exportTransactions";

--- a/apps/web-next/src/utility/index.ts
+++ b/apps/web-next/src/utility/index.ts
@@ -3,6 +3,8 @@ export * from "./supabaseClient";
 export * from "./currency";
 export * from "./rpc";
 export * from "./dateDisplay";
+export * from "./dateRanges";
+export * from "./dayjsValue";
 export * from "./datePickerFormats";
 export * from "./csvExport";
 export * from "./exportTransactions";

--- a/apps/web-next/src/utility/index.ts
+++ b/apps/web-next/src/utility/index.ts
@@ -6,6 +6,7 @@ export * from "./dateDisplay";
 export * from "./dateRanges";
 export * from "./dayjsValue";
 export * from "./selectFilterOption";
+export * from "./selectOptions";
 export * from "./userSettings";
 export * from "./datePickerFormats";
 export * from "./csvExport";

--- a/apps/web-next/src/utility/selectFilterOption.ts
+++ b/apps/web-next/src/utility/selectFilterOption.ts
@@ -1,0 +1,14 @@
+import type { DefaultOptionType } from "antd/es/select";
+
+/**
+ * antd `filterOption` for selects whose options carry no searchable field
+ * beyond their visible label (unlike categories, which also match on a
+ * parent-inclusive search text — see `categoryFilterOption`).
+ */
+export const simpleLabelFilterOption = (
+  input: string,
+  option?: DefaultOptionType
+): boolean =>
+  String(option?.label ?? "")
+    .toLowerCase()
+    .includes(input.toLowerCase());

--- a/apps/web-next/src/utility/selectOptions.ts
+++ b/apps/web-next/src/utility/selectOptions.ts
@@ -1,0 +1,14 @@
+/**
+ * A stored id (a default category/bank account, etc.) can outlive its target —
+ * FKs use ON DELETE SET NULL, which only fires on a hard delete, and this app
+ * soft-deletes. `*_with_usage` views already exclude soft-deleted rows, so
+ * treating "not in options" as "unset" renders a stale reference as empty
+ * instead of a raw id.
+ */
+export const valueIfStillAvailable = (
+  id: string | null | undefined,
+  options: readonly { value?: unknown }[]
+): string | undefined =>
+  id && options.some((option) => String(option.value) === id)
+    ? id
+    : undefined;

--- a/apps/web-next/src/utility/userSettings.ts
+++ b/apps/web-next/src/utility/userSettings.ts
@@ -1,0 +1,13 @@
+import type { Database } from "../types/database.types";
+import { supabaseClient } from "./supabaseClient";
+
+type UserSettingsUpdate = Database["public"]["Tables"]["user_settings"]["Update"];
+
+/**
+ * Upserts a partial patch onto the caller's user_settings row. `user_id` is
+ * deliberately omitted from every caller's payload — the set_user_id trigger
+ * fills it in server-side — so this is the one place that (user_id) conflict
+ * target is written, shared by the currency and transaction-defaults settings.
+ */
+export const upsertUserSettings = (patch: UserSettingsUpdate) =>
+  supabaseClient.from("user_settings").upsert(patch, { onConflict: "user_id" });

--- a/docs/superpowers/plans/2026-08-01-transaction-defaults-and-export-presets.md
+++ b/docs/superpowers/plans/2026-08-01-transaction-defaults-and-export-presets.md
@@ -1,0 +1,171 @@
+# Transaction entry defaults & export range presets — implementation plan
+
+**Date:** 2026-08-01
+**Status:** Not started
+**Scope:** In — default date on the transaction Create form; user-configurable per-type default Category/Bank Account plus a default Type, edited in a new Settings tab; preset date ranges on Settings → Export. Out — any change to the transaction Edit form, and any change to the bulk-upload/export payload shapes.
+
+## Progress Log
+
+<!-- Newest entry first. One entry per session, even sessions with no code progress. -->
+
+- **2026-08-01** — Plan created from a UX review of the live web UI. Not started.
+
+---
+
+## Context
+
+Three friction points found while using the web UI:
+
+1. **Every new transaction requires picking a date manually.** `transactions/create.tsx` renders the Date `DatePicker` with no initial value, so the overwhelmingly common case (entering today's transaction) costs an extra interaction every time.
+2. **Category and Bank Account are always empty on Create.** Most users have a habitual account/category per transaction type (Earn → current account + Salary, Spend → credit card + Groceries, Save → investment account). Today all of that is re-selected from scratch on every entry, and there is no place to express a default.
+3. **Settings → Export forces manual date entry.** `ExportSection` uses a bare `DatePicker.RangePicker` with the Export button disabled until both ends are typed. "Last month" / "Last year" are the common cases and cost two date entries each.
+
+Intended outcome: opening Create pre-fills Date, Type, Category and Bank Account so a typical entry is amount + save; and exporting a common period is one click.
+
+### Decisions taken
+
+- Defaults are edited in a **new Settings → Transactions tab**, not via inline "default" flags on the Categories/Bank Accounts list pages. Keeps preference data out of the domain tables (matching the existing `user_settings`/currency precedent) and avoids touching the bulk-upload/export/reset payload shapes.
+- The default **Bank Account varies per transaction type**. This is also why inline flags don't work: `bank-accounts/list.tsx` is a bare generic `ResourceList` with no type dimension to hang a per-type default off. (Categories *are* type-scoped — `categories/list.tsx:62` has a Segmented — so inline would have worked there, but only there.)
+- A **default transaction Type** is included, since the settings-tab approach gives it a natural home. Today a type is only implied when arriving from the transactions list's Create button (`transactions/list.tsx:235-239` passes `?source=transactions-list&type=`); `/transactions/create` reached from the sidebar or the kbar "Add Transaction" action (`hooks/useQuickActions.ts`) arrives with nothing set.
+
+---
+
+## 1. Default date = today
+
+`apps/web-next/src/pages/transactions/create.tsx` — add `date: dayjs()` to the `mergedInitialValues` memo (currently lines 43-56). The existing `getValueProps` on the Date `Form.Item` already normalises through `dayjs()`, and `useTransactionForm.handleFinish` already serialises a Dayjs to `YYYY-MM-DD`, so no other change is needed.
+
+`transactions/edit.tsx` is untouched — it loads the persisted date.
+
+---
+
+## 2. Per-type defaults for Category, Bank Account, and Type
+
+### 2a. Migration
+
+`supabase migration new transaction_defaults`
+
+**Default type** — new nullable column on the existing settings table:
+
+```sql
+ALTER TABLE public.user_settings
+  ADD COLUMN IF NOT EXISTS default_transaction_type public.transaction_type;
+```
+
+**New table** for the per-type pair:
+
+```sql
+CREATE TABLE IF NOT EXISTS public.user_transaction_defaults (
+    user_id         UUID NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+    type            public.transaction_type NOT NULL,
+    category_id     UUID REFERENCES public.categories (id) ON DELETE SET NULL,
+    bank_account_id UUID REFERENCES public.bank_accounts (id) ON DELETE SET NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (user_id, type)
+);
+```
+
+Follow the boilerplate documented in `docs/database/schema-and-migrations.md`:
+
+- `ENABLE ROW LEVEL SECURITY` plus the standard four policies named `user_transaction_defaults_{select,insert,update,delete}`, each predicated on `user_id = (SELECT auth.uid())`. Copy the shape from `supabase/migrations/20260425000002_add_user_settings.sql`.
+- `BEFORE INSERT` trigger calling `public.tg_set_user_id()`, `BEFORE UPDATE` trigger calling `public.tg_set_updated_at()`.
+
+**Referential validation trigger.** FKs alone are not enough — they don't check ownership, don't check that the category's `type` matches the row's `type`, and don't fire on soft delete. Add a `BEFORE INSERT OR UPDATE` trigger following the `check_transaction_bank_account` idiom (compare against `NEW.user_id`, not `auth.uid()`), raising `ERRCODE = '23514'`:
+
+- `category_id`, when not null: must exist in `public.categories` with `user_id = NEW.user_id AND type = NEW.type AND deleted_at IS NULL`.
+- `bank_account_id`, when not null: must exist in `public.bank_accounts` with `user_id = NEW.user_id AND deleted_at IS NULL`.
+
+> ⚠️ **Trigger naming matters here.** Postgres fires same-timing triggers in alphabetical order, so the validation trigger must sort *after* `set_user_id_on_user_transaction_defaults` or it will read a null `NEW.user_id`. Name it `validate_user_transaction_defaults_refs` (`v` > `s`) — a `check_*` name would run first and break.
+
+**`reset_user_data`.** `CREATE OR REPLACE` it (current definition: `supabase/migrations/20260321134117_reset_user_data_delete_budgets.sql`) to also `DELETE FROM public.user_transaction_defaults WHERE user_id = v_uid;` and clear `user_settings.default_transaction_type`. The `ON DELETE SET NULL` FKs mean the reset wouldn't error without this, but it would leave the user pointing at defaults whose categories no longer exist. Keep the returned JSON shape unchanged (no new count key) so `DataResetSection` needs no edit; update the function's `COMMENT` to mention the cleared defaults.
+
+### 2b. Types
+
+Run `supabase gen types typescript --local > types.gen.ts` at the repo root, then manually sync the new table and column into `apps/web-next/src/types/database.types.ts` — per `docs/superpowers/plans/2026-07-25-deep-code-review-fixes.md` these two are not auto-synced, and the checked-in file has known pre-existing drift (`transactions.user_id` nullability) that must be left alone.
+
+### 2c. Read/write layer
+
+New `apps/web-next/src/hooks/useTransactionDefaults.ts`, exported from `hooks/index.ts`:
+
+- Reads via Refine `useList({ resource: "user_transaction_defaults", pagination: { mode: "off" } })`, returning a `Record<TransactionType, { categoryId, bankAccountId }>` shape, plus the default type.
+- Writes via `supabaseClient.from("user_transaction_defaults").upsert({ type, category_id, bank_account_id }, { onConflict: "user_id,type" })`, followed by `useInvalidate()`. This mirrors `CurrencyContextProvider.setCurrency` (`contexts/currency/index.tsx:88-103`), which relies on the same trigger-populated `user_id` during conflict arbitration. Direct `supabaseClient` use rather than Refine mutations because the table has a composite PK and no `id` column, which Refine's Supabase provider assumes.
+- `default_transaction_type` reads/writes go to `user_settings` using the same upsert pattern already used for currency.
+
+### 2d. Settings UI
+
+`apps/web-next/src/pages/settings/index.tsx` — new `TransactionDefaultsSection` component and a new `"transactions"` tab inserted between `general` and `import-export` in the `Tabs` `items` array (line 549+):
+
+```
+Settings
+[ General | Transactions | Import & Export | ⚠ Danger Zone ]
+
+┌ Transaction Defaults ─────────────────────────┐
+│ Default type:  [ Spend           ▾]           │
+│                                               │
+│ Type   Default Category    Default Account    │
+│ Earn   [ Salary       ▾]   [ Monzo       ▾]   │
+│ Spend  [ Food/Grocer. ▾]   [ Amex        ▾]   │
+│ Save   [ Emergency f. ▾]   [ Vanguard    ▾]   │
+└───────────────────────────────────────────────┘
+```
+
+- One row per entry in `TRANSACTION_TYPES` (`constants/transactionTypes.ts`), labelled via `TRANSACTION_TYPE_LABELS`.
+- Category options: `categories_with_usage` filtered by that row's type, then the existing helpers from `utility/categoryHierarchy.ts` — `isLeafCategory`, `compareCategoriesByHierarchyLabel`, `categoryLabel`, `categorySearchText` — exactly as `transactions/create.tsx:68-75` already does. Defaults may only point at leaf categories, consistent with the Create form.
+- Bank account options: `bank_accounts_with_usage`, sorted by name.
+- All three selects `allowClear`, so a default can be removed.
+- **Stale-reference guard:** only pass `value` to a `Select` when the stored id is present in that select's loaded options. The `*_with_usage` views already exclude soft-deleted rows, so a soft-deleted default renders as empty rather than as a raw UUID. (The `ON DELETE SET NULL` FKs only cover hard deletes; the app soft-deletes.)
+
+### 2e. Create form prefill
+
+`apps/web-next/src/pages/transactions/create.tsx`:
+
+- Initial `type` becomes the `?type=` param (existing `initialType` memo) **falling back to** the stored default type.
+- A `useEffect` keyed on the resolved type, the loaded option lists, and the defaults: when `category_id` / `bank_account_id` are currently empty, set them from that type's defaults — but only if the id is present in the corresponding loaded options list (same stale guard as above).
+- Extend the Type `Select`'s existing `onChange` (lines 113-115, currently clears `category_id`) to clear `bank_account_id` too. Both fields then re-derive from the new type's defaults via the effect.
+
+> **Behaviour note:** switching Type mid-entry discards an already-chosen Bank Account, the way it already discards the chosen Category. This keeps the rule simple and predictable ("Type drives both") and avoids touched-state tracking. Type switches mid-entry are rare.
+
+---
+
+## 3. Export date-range presets
+
+`apps/web-next/src/utility/dateRanges.ts` — add `getExportRangePresets()` returning AntD `presets` entries: This month, Last month, Last 3 months, This year, Last year, Last 12 months. Export from `utility/index.ts`.
+
+Export it as a **function**, not a module-level constant, so "today" is evaluated per render. `constants/dateOptions.ts` already demonstrates the constant form's bug — its `currentYear` is frozen at module load and goes stale in a long-lived tab.
+
+Wire into `ExportSection` in `pages/settings/index.tsx:373-379`: `<DatePicker.RangePicker presets={getExportRangePresets()} ... />`. The existing `onChange` handler already sets `range`, which un-disables the Export button, so preset clicks work with no further change.
+
+---
+
+## Implementation order
+
+- [ ] 1. Migration: `user_settings.default_transaction_type`, `user_transaction_defaults` table, RLS, triggers, `reset_user_data` update. Apply with `supabase migration up`.
+- [ ] 2. pgTAP suite `supabase/tests/user_transaction_defaults_rls_test.sql`; `supabase test db` green.
+- [ ] 3. Regenerate `types.gen.ts` and manually sync `apps/web-next/src/types/database.types.ts`.
+- [ ] 4. `useTransactionDefaults` hook + `hooks/index.ts` export.
+- [ ] 5. Settings → Transactions tab (`TransactionDefaultsSection`).
+- [ ] 6. Create form: default date, default type, prefill effect, Type `onChange` clearing both fields.
+- [ ] 7. `getExportRangePresets()` + wire into `ExportSection`.
+- [ ] 8. E2E tests (including the `settings-tabs.spec.ts` update); `npm run test:e2e:ci` green.
+
+## Critical files
+
+- `apps/web-next/src/pages/transactions/create.tsx` — all of step 1 and the prefill in step 2e.
+- `apps/web-next/src/pages/settings/index.tsx` — new tab (2d) and export presets (3).
+- `apps/web-next/src/contexts/currency/index.tsx` — the precedent for reading/writing `user_settings` and for the trigger-populated-`user_id` upsert pattern.
+- `supabase/migrations/20260425000002_add_user_settings.sql` — RLS/trigger boilerplate to copy.
+- `supabase/migrations/20260321134117_reset_user_data_delete_budgets.sql` — current `reset_user_data` body to `CREATE OR REPLACE`.
+- `apps/web-next/src/utility/categoryHierarchy.ts` — leaf filtering, labelling and sort helpers to reuse rather than reimplement.
+- `apps/web-next/e2e/tests/settings-tabs.spec.ts` — asserts the current three-tab set; **will fail** until updated.
+
+## Verification plan
+
+1. `supabase migration up` — migration applies cleanly.
+2. `supabase test db` — new suite asserts: RLS isolation between two users; a category belonging to another user is rejected; a category whose `type` differs from the row's `type` is rejected; a soft-deleted category is rejected; `reset_user_data` clears the rows.
+3. `cd apps/web-next && npm run check-types && npm run lint`.
+4. `npm run test:e2e:ci`, covering:
+   - `transactions.spec.ts` — Create opens with today's date; after setting defaults, Create pre-fills Category + Bank Account; switching Type swaps both to the new type's defaults.
+   - `transaction-defaults.spec.ts` (new) — set/clear defaults in the Settings tab, confirm they persist across reload.
+   - `transactions-export.spec.ts` — clicking the "Last month" preset populates the range and enables Export (reuse the page objects from the existing `fillExportDateRange` helper).
+   - `settings-tabs.spec.ts` — updated for the four-tab set.
+5. Manual smoke: `npm run dev` → Settings → Transactions, set a default per type → `/transactions/create` **from the sidebar** (not the list, to exercise the no-`?type=` path) → confirm Date/Type/Category/Bank Account all pre-filled → Settings → Import & Export → click "Last month" → Export.

--- a/docs/superpowers/plans/2026-08-01-transaction-defaults-and-export-presets.md
+++ b/docs/superpowers/plans/2026-08-01-transaction-defaults-and-export-presets.md
@@ -1,12 +1,21 @@
 # Transaction entry defaults & export range presets — implementation plan
 
 **Date:** 2026-08-01
-**Status:** Not started
+**Status:** Implemented — all steps done, `supabase test db` and the full Playwright suite green
 **Scope:** In — default date on the transaction Create form; user-configurable per-type default Category/Bank Account plus a default Type, edited in a new Settings tab; preset date ranges on Settings → Export. Out — any change to the transaction Edit form, and any change to the bulk-upload/export payload shapes.
 
 ## Progress Log
 
 <!-- Newest entry first. One entry per session, even sessions with no code progress. -->
+
+- **2026-08-01** — All 8 steps implemented. `supabase test db` 275 tests green (18 files); full Playwright suite 118 tests green.
+
+  Two things diverged from the plan, both in the Create form (§2e):
+
+  1. **`initialValues` had to be frozen at mount.** The plan said "add `date: dayjs()` to the `mergedInitialValues` memo". That memo recomputes when `formProps.initialValues` changes identity, producing a fresh `dayjs()` — and antd re-seeds the field from the new object, discarding a date the user is part-way through typing. Replaced the memo with a `useState(() => …)` initialiser, and moved the default `type` out of `initialValues` entirely (it can arrive asynchronously with the stored default, so an effect applies it instead).
+  2. **`getValueProps` was rewrapping an already-Dayjs value.** `dayjs(value)` returns a new instance on every render; rc-picker reads a new `value` identity as an external change and throws away in-progress typed text. Any background query resolving mid-typing silently reverted the date. This was pre-existing but latent — the two new queries this feature adds widened the window enough that ~5 existing tests began failing intermittently. Extracted `toDayjs()` (`utility/dayjsValue.ts`), which returns the same instance when the value is already a Dayjs, and applied it to both the create and edit forms.
+
+  Also added, beyond the plan: `toLeafCategoryOptions` / `categoryFilterOption` in `utility/categoryHierarchy.ts`, replacing the same filter/sort/map and filter predicate that had been copy-pasted across the create form, the edit form, and the new settings grid; and an `.sr-only` class in `styles/global.css` for the grid's per-cell labels.
 
 - **2026-08-01** — Plan created from a UX review of the live web UI. Not started.
 
@@ -139,14 +148,14 @@ Wire into `ExportSection` in `pages/settings/index.tsx:373-379`: `<DatePicker.Ra
 
 ## Implementation order
 
-- [ ] 1. Migration: `user_settings.default_transaction_type`, `user_transaction_defaults` table, RLS, triggers, `reset_user_data` update. Apply with `supabase migration up`.
-- [ ] 2. pgTAP suite `supabase/tests/user_transaction_defaults_rls_test.sql`; `supabase test db` green.
-- [ ] 3. Regenerate `types.gen.ts` and manually sync `apps/web-next/src/types/database.types.ts`.
-- [ ] 4. `useTransactionDefaults` hook + `hooks/index.ts` export.
-- [ ] 5. Settings → Transactions tab (`TransactionDefaultsSection`).
-- [ ] 6. Create form: default date, default type, prefill effect, Type `onChange` clearing both fields.
-- [ ] 7. `getExportRangePresets()` + wire into `ExportSection`.
-- [ ] 8. E2E tests (including the `settings-tabs.spec.ts` update); `npm run test:e2e:ci` green.
+- [x] 1. Migration: `user_settings.default_transaction_type`, `user_transaction_defaults` table, RLS, triggers, `reset_user_data` update. Apply with `supabase migration up`.
+- [x] 2. pgTAP suite `supabase/tests/user_transaction_defaults_rls_test.sql`; `supabase test db` green.
+- [x] 3. Regenerate `types.gen.ts` and manually sync `apps/web-next/src/types/database.types.ts`.
+- [x] 4. `useTransactionDefaults` hook + `hooks/index.ts` export.
+- [x] 5. Settings → Transactions tab (`TransactionDefaultsSection`).
+- [x] 6. Create form: default date, default type, prefill effect, Type `onChange` clearing both fields.
+- [x] 7. `getExportRangePresets()` + wire into `ExportSection`.
+- [x] 8. E2E tests (including the `settings-tabs.spec.ts` update); `npm run test:e2e:ci` green.
 
 ## Critical files
 

--- a/supabase/migrations/20260801210639_transaction_defaults.sql
+++ b/supabase/migrations/20260801210639_transaction_defaults.sql
@@ -1,0 +1,178 @@
+-- Per-transaction-type entry defaults.
+--
+-- Lets a user nominate, for each transaction type, the category and bank account
+-- that the Create form should pre-fill, plus an overall default type so a Create
+-- form reached without a ?type= param still opens fully populated.
+--
+-- These are user *preferences*, so they live alongside user_settings rather than
+-- as flags on categories/bank_accounts — that keeps the bulk-upload, export and
+-- reset payload shapes untouched.
+
+-- === Default transaction type =============================================
+ALTER TABLE public.user_settings
+  ADD COLUMN IF NOT EXISTS default_transaction_type public.transaction_type;
+
+COMMENT ON COLUMN public.user_settings.default_transaction_type IS
+  'Transaction type pre-selected on the Create form when no type is supplied via the URL. NULL means no default.';
+
+-- === Per-type category / bank account defaults ============================
+CREATE TABLE IF NOT EXISTS public.user_transaction_defaults (
+    user_id         UUID NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+    type            public.transaction_type NOT NULL,
+    -- ON DELETE SET NULL only covers hard deletes; categories and bank_accounts
+    -- are soft-deleted in this app, so readers must additionally ignore rows
+    -- pointing at a deleted_at IS NOT NULL target. The validation trigger below
+    -- stops a soft-deleted row from ever being *stored* as a default.
+    category_id     UUID REFERENCES public.categories (id) ON DELETE SET NULL,
+    bank_account_id UUID REFERENCES public.bank_accounts (id) ON DELETE SET NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (user_id, type)
+);
+
+COMMENT ON TABLE public.user_transaction_defaults IS
+  'Per-transaction-type default category and bank account used to pre-fill the transaction Create form. At most one row per (user, type).';
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.user_transaction_defaults
+  TO anon, authenticated, service_role;
+
+ALTER TABLE public.user_transaction_defaults ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS user_transaction_defaults_select ON public.user_transaction_defaults;
+CREATE POLICY user_transaction_defaults_select ON public.user_transaction_defaults
+    FOR SELECT USING (user_id = (SELECT auth.uid()));
+
+DROP POLICY IF EXISTS user_transaction_defaults_insert ON public.user_transaction_defaults;
+CREATE POLICY user_transaction_defaults_insert ON public.user_transaction_defaults
+    FOR INSERT WITH CHECK (user_id = (SELECT auth.uid()));
+
+DROP POLICY IF EXISTS user_transaction_defaults_update ON public.user_transaction_defaults;
+CREATE POLICY user_transaction_defaults_update ON public.user_transaction_defaults
+    FOR UPDATE USING (user_id = (SELECT auth.uid()))
+    WITH CHECK (user_id = (SELECT auth.uid()));
+
+DROP POLICY IF EXISTS user_transaction_defaults_delete ON public.user_transaction_defaults;
+CREATE POLICY user_transaction_defaults_delete ON public.user_transaction_defaults
+    FOR DELETE USING (user_id = (SELECT auth.uid()));
+
+-- Referential validation. The foreign keys above guarantee the rows exist, but
+-- not that they belong to this user, that the category's type matches, or that
+-- either is still live. Compares against NEW.user_id rather than auth.uid() so
+-- the check also holds if a SECURITY DEFINER path ever writes this table.
+CREATE
+OR REPLACE FUNCTION public.validate_user_transaction_defaults_refs () RETURNS TRIGGER LANGUAGE plpgsql
+SET
+  search_path = '' AS $$
+begin
+  if new.category_id is not null then
+    if not exists (
+      select 1 from public.categories c
+      where c.id = new.category_id
+        and c.user_id = new.user_id
+        and c.type = new.type
+        and c.deleted_at is null
+    ) then
+      raise exception 'Default category must be a live category of the same type owned by the user' using errcode = '23514';
+    end if;
+  end if;
+
+  if new.bank_account_id is not null then
+    if not exists (
+      select 1 from public.bank_accounts b
+      where b.id = new.bank_account_id
+        and b.user_id = new.user_id
+        and b.deleted_at is null
+    ) then
+      raise exception 'Default bank account does not belong to the user' using errcode = '23514';
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+DROP TRIGGER IF EXISTS set_user_id_on_user_transaction_defaults ON public.user_transaction_defaults;
+CREATE TRIGGER set_user_id_on_user_transaction_defaults
+    BEFORE INSERT ON public.user_transaction_defaults
+    FOR EACH ROW EXECUTE FUNCTION public.tg_set_user_id ();
+
+DROP TRIGGER IF EXISTS set_updated_at_on_user_transaction_defaults ON public.user_transaction_defaults;
+CREATE TRIGGER set_updated_at_on_user_transaction_defaults
+    BEFORE UPDATE ON public.user_transaction_defaults
+    FOR EACH ROW EXECUTE FUNCTION public.tg_set_updated_at ();
+
+-- NOTE: Postgres fires BEFORE triggers of the same timing in *alphabetical* order.
+-- This one must sort after set_user_id_on_user_transaction_defaults, or it would
+-- validate against a NULL NEW.user_id on insert. "validate_" > "set_" — do not
+-- rename this to check_* without re-checking that ordering.
+DROP TRIGGER IF EXISTS validate_user_transaction_defaults_refs ON public.user_transaction_defaults;
+CREATE TRIGGER validate_user_transaction_defaults_refs
+    BEFORE INSERT OR UPDATE ON public.user_transaction_defaults
+    FOR EACH ROW EXECUTE FUNCTION public.validate_user_transaction_defaults_refs ();
+
+-- === Keep Reset All Data honest ===========================================
+-- reset_user_data hard-deletes categories and bank_accounts, so the FKs above
+-- would leave defaults rows behind with NULLed-out columns. Clear them outright,
+-- along with the default type, so a reset user starts from a clean slate.
+-- Return shape is deliberately unchanged — the Settings UI renders it verbatim.
+CREATE
+OR REPLACE FUNCTION public.reset_user_data () RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+SET
+  search_path = '' AS $$
+DECLARE
+  v_uid uuid;
+  v_transactions_deleted bigint := 0;
+  v_categories_deleted bigint := 0;
+  v_tags_deleted bigint := 0;
+  v_bank_accounts_deleted bigint := 0;
+  v_budgets_deleted bigint := 0;
+BEGIN
+  v_uid := auth.uid();
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'reset_user_data: not authenticated' USING ERRCODE = '28000';
+  END IF;
+
+  -- Entry defaults go first: they reference categories and bank_accounts, and
+  -- they are preferences rather than data, so they are not counted in the result.
+  DELETE FROM public.user_transaction_defaults WHERE user_id = v_uid;
+
+  UPDATE public.user_settings
+     SET default_transaction_type = NULL
+   WHERE user_id = v_uid
+     AND default_transaction_type IS NOT NULL;
+
+  -- Delete in FK-safe order. Budgets go first so their linked rows cascade away
+  -- before categories/tags are removed.
+  DELETE FROM public.budgets WHERE user_id = v_uid;
+  GET DIAGNOSTICS v_budgets_deleted = ROW_COUNT;
+
+  DELETE FROM public.transactions WHERE user_id = v_uid;
+  GET DIAGNOSTICS v_transactions_deleted = ROW_COUNT;
+
+  DELETE FROM public.categories WHERE user_id = v_uid;
+  GET DIAGNOSTICS v_categories_deleted = ROW_COUNT;
+
+  DELETE FROM public.tags WHERE user_id = v_uid;
+  GET DIAGNOSTICS v_tags_deleted = ROW_COUNT;
+
+  DELETE FROM public.bank_accounts WHERE user_id = v_uid;
+  GET DIAGNOSTICS v_bank_accounts_deleted = ROW_COUNT;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'budgets_deleted', v_budgets_deleted,
+    'transactions_deleted', v_transactions_deleted,
+    'categories_deleted', v_categories_deleted,
+    'tags_deleted', v_tags_deleted,
+    'bank_accounts_deleted', v_bank_accounts_deleted
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.reset_user_data () IS 'Permanently deletes all personal financial data for the authenticated user, including:
+- All budgets (and their linked budget categories/tags)
+- All transactions
+- All categories
+- All tags
+- All bank accounts
+It also clears the user''s transaction entry defaults (per-type category/bank account and default type), which reference the deleted rows. Those are not included in the returned counts.';

--- a/supabase/tests/user_transaction_defaults_rls_test.sql
+++ b/supabase/tests/user_transaction_defaults_rls_test.sql
@@ -1,0 +1,221 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+
+select plan(16);
+
+-- Scratch table for passing ids between the two authenticated sessions below.
+-- Created as postgres before any authenticate_as, then opened up so both test
+-- roles can write to it.
+create temporary table t_ids (k text primary key, v uuid);
+grant all on t_ids to public;
+
+select tests.create_supabase_user('utd_user1@test.com');
+select tests.create_supabase_user('utd_user2@test.com');
+
+-- ── Fixtures ──────────────────────────────────────────────────────────────────
+
+select tests.authenticate_as('utd_user1@test.com');
+
+insert into public.categories (type, name) values
+  ('spend'::public.transaction_type, 'Groceries'),
+  ('earn'::public.transaction_type, 'Salary'),
+  ('spend'::public.transaction_type, 'Doomed');
+insert into public.bank_accounts (name) values ('Checking'), ('DoomedBank');
+
+insert into t_ids (k, v)
+select 'u1_groceries', id from public.categories where name = 'Groceries';
+insert into t_ids (k, v)
+select 'u1_salary', id from public.categories where name = 'Salary';
+insert into t_ids (k, v)
+select 'u1_doomed_cat', id from public.categories where name = 'Doomed';
+insert into t_ids (k, v)
+select 'u1_checking', id from public.bank_accounts where name = 'Checking';
+insert into t_ids (k, v)
+select 'u1_doomed_bank', id from public.bank_accounts where name = 'DoomedBank';
+
+select tests.authenticate_as('utd_user2@test.com');
+
+insert into public.categories (type, name) values ('spend'::public.transaction_type, 'Transport');
+insert into public.bank_accounts (name) values ('Monzo');
+
+insert into t_ids (k, v)
+select 'u2_transport', id from public.categories where name = 'Transport';
+insert into t_ids (k, v)
+select 'u2_monzo', id from public.bank_accounts where name = 'Monzo';
+
+-- User 2 gets a defaults row of their own, so the reset isolation check at the
+-- end has something to assert survived.
+insert into public.user_transaction_defaults (type, category_id, bank_account_id)
+select 'spend'::public.transaction_type,
+       (select v from t_ids where k = 'u2_transport'),
+       (select v from t_ids where k = 'u2_monzo');
+
+-- ── Happy path ────────────────────────────────────────────────────────────────
+
+select tests.authenticate_as('utd_user1@test.com');
+
+-- 1) user_id is supplied by the set_user_id trigger, not the client
+select lives_ok(
+    $$ insert into public.user_transaction_defaults (type, category_id, bank_account_id)
+       select 'spend'::public.transaction_type,
+              (select v from t_ids where k = 'u1_groceries'),
+              (select v from t_ids where k = 'u1_checking') $$,
+    'User 1 can insert a default without supplying user_id'
+);
+
+-- 2) The row reads back scoped to the inserting user
+select results_eq(
+    $$ select type, category_id, bank_account_id from public.user_transaction_defaults $$,
+    $$ select 'spend'::public.transaction_type,
+              (select v from t_ids where k = 'u1_groceries'),
+              (select v from t_ids where k = 'u1_checking') $$,
+    'User 1 reads back their own default'
+);
+
+-- 3) (user_id, type) is the conflict target the app upserts on
+select lives_ok(
+    $$ insert into public.user_transaction_defaults (type, category_id, bank_account_id)
+       select 'spend'::public.transaction_type,
+              (select v from t_ids where k = 'u1_groceries'),
+              (select v from t_ids where k = 'u1_doomed_bank')
+       on conflict (user_id, type) do update
+         set category_id = excluded.category_id,
+             bank_account_id = excluded.bank_account_id $$,
+    'Upsert on (user_id, type) replaces an existing default'
+);
+
+-- 4)
+select ok(
+    (select updated_at >= created_at from public.user_transaction_defaults),
+    'updated_at is greater than or equal to created_at after upsert'
+);
+
+-- 5) Clearing a default is allowed — both columns are nullable
+select lives_ok(
+    $$ insert into public.user_transaction_defaults (type, category_id, bank_account_id)
+       values ('spend'::public.transaction_type, null, null)
+       on conflict (user_id, type) do update
+         set category_id = null, bank_account_id = null $$,
+    'A default can be cleared back to NULL'
+);
+
+-- ── Referential validation ────────────────────────────────────────────────────
+
+-- 6) The category's type must match the row's type
+select throws_ok(
+    $$ insert into public.user_transaction_defaults (type, category_id)
+       select 'earn'::public.transaction_type,
+              (select v from t_ids where k = 'u1_groceries') $$,
+    '23514',
+    null,
+    'A spend category is rejected as the earn default'
+);
+
+-- 7) Soft-deleted rows must not be storable as a default
+update public.categories set deleted_at = now()
+ where id = (select v from t_ids where k = 'u1_doomed_cat');
+
+select throws_ok(
+    $$ insert into public.user_transaction_defaults (type, category_id)
+       select 'save'::public.transaction_type,
+              (select v from t_ids where k = 'u1_doomed_cat') $$,
+    '23514',
+    null,
+    'A soft-deleted category is rejected as a default'
+);
+
+-- 8)
+update public.bank_accounts set deleted_at = now()
+ where id = (select v from t_ids where k = 'u1_doomed_bank');
+
+select throws_ok(
+    $$ insert into public.user_transaction_defaults (type, bank_account_id)
+       select 'save'::public.transaction_type,
+              (select v from t_ids where k = 'u1_doomed_bank') $$,
+    '23514',
+    null,
+    'A soft-deleted bank account is rejected as a default'
+);
+
+-- 9) Cross-user references are rejected — the FK alone would happily accept these
+select throws_ok(
+    $$ insert into public.user_transaction_defaults (type, category_id)
+       select 'save'::public.transaction_type,
+              (select v from t_ids where k = 'u2_transport') $$,
+    '23514',
+    null,
+    'Another user''s category is rejected as a default'
+);
+
+-- 10)
+select throws_ok(
+    $$ insert into public.user_transaction_defaults (type, bank_account_id)
+       select 'save'::public.transaction_type,
+              (select v from t_ids where k = 'u2_monzo') $$,
+    '23514',
+    null,
+    'Another user''s bank account is rejected as a default'
+);
+
+-- ── RLS isolation ─────────────────────────────────────────────────────────────
+
+select tests.authenticate_as('utd_user2@test.com');
+
+-- 11) User 2 sees only their own row, not User 1's
+select results_eq(
+    $$ select count(*) from public.user_transaction_defaults $$,
+    array[1::bigint],
+    'User 2 cannot see User 1 defaults'
+);
+
+-- 12) ...and cannot reach User 1's row to update it
+select is_empty(
+    $$ update public.user_transaction_defaults set category_id = null
+        where user_id <> (select auth.uid()) returning 1 $$,
+    'User 2 cannot update User 1 defaults'
+);
+
+-- ── Default transaction type on user_settings ─────────────────────────────────
+
+select tests.authenticate_as('utd_user1@test.com');
+
+-- 13)
+select lives_ok(
+    $$ insert into public.user_settings (currency, default_transaction_type)
+       values ('GBP', 'spend'::public.transaction_type)
+       on conflict (user_id) do update
+         set default_transaction_type = 'spend'::public.transaction_type $$,
+    'default_transaction_type accepts a valid transaction type'
+);
+
+-- ── reset_user_data clears the preferences too ────────────────────────────────
+
+select public.reset_user_data();
+
+-- 14)
+select is(
+    (select count(*) from public.user_transaction_defaults),
+    0::bigint,
+    'reset_user_data clears User 1 transaction defaults'
+);
+
+-- 15)
+select is(
+    (select default_transaction_type from public.user_settings),
+    null::public.transaction_type,
+    'reset_user_data clears User 1 default transaction type'
+);
+
+-- 16) User 2's preferences are untouched by User 1's reset
+select tests.authenticate_as('utd_user2@test.com');
+
+select results_eq(
+    $$ select count(*) from public.user_transaction_defaults $$,
+    array[1::bigint],
+    'User 2 defaults survive User 1 reset'
+);
+
+select * from finish();
+
+rollback;

--- a/types.gen.ts
+++ b/types.gen.ts
@@ -489,22 +489,87 @@ export type Database = {
         Row: {
           created_at: string
           currency: string
+          default_transaction_type:
+            | Database["public"]["Enums"]["transaction_type"]
+            | null
           updated_at: string
           user_id: string
         }
         Insert: {
           created_at?: string
           currency?: string
+          default_transaction_type?:
+            | Database["public"]["Enums"]["transaction_type"]
+            | null
           updated_at?: string
           user_id: string
         }
         Update: {
           created_at?: string
           currency?: string
+          default_transaction_type?:
+            | Database["public"]["Enums"]["transaction_type"]
+            | null
           updated_at?: string
           user_id?: string
         }
         Relationships: []
+      }
+      user_transaction_defaults: {
+        Row: {
+          bank_account_id: string | null
+          category_id: string | null
+          created_at: string
+          type: Database["public"]["Enums"]["transaction_type"]
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          bank_account_id?: string | null
+          category_id?: string | null
+          created_at?: string
+          type: Database["public"]["Enums"]["transaction_type"]
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          bank_account_id?: string | null
+          category_id?: string | null
+          created_at?: string
+          type?: Database["public"]["Enums"]["transaction_type"]
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "user_transaction_defaults_bank_account_id_fkey"
+            columns: ["bank_account_id"]
+            isOneToOne: false
+            referencedRelation: "bank_accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "user_transaction_defaults_bank_account_id_fkey"
+            columns: ["bank_account_id"]
+            isOneToOne: false
+            referencedRelation: "bank_accounts_with_usage"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "user_transaction_defaults_category_id_fkey"
+            columns: ["category_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "user_transaction_defaults_category_id_fkey"
+            columns: ["category_id"]
+            isOneToOne: false
+            referencedRelation: "categories_with_usage"
+            referencedColumns: ["id"]
+          },
+        ]
       }
     }
     Views: {


### PR DESCRIPTION
## Why

Three friction points found while using the web UI:

1. **Every new transaction required picking a date manually.** The Create form's `DatePicker` had no initial value, so the overwhelmingly common case — entering today's transaction — cost an extra interaction every time.
2. **Category and Bank Account were always empty on Create.** Most users have a habitual account/category per transaction type (Earn → current account + Salary, Spend → credit card + Groceries, Save → investment account), and there was no way to express that.
3. **Settings → Export forced manual date entry.** The Export button stayed disabled until both ends of the range were typed, and "last month" / "last year" are the common cases.

Outcome: opening Create pre-fills Date, Type, Category and Bank Account, so a typical entry is amount + save; exporting a common period is one click.

## What Changed

**Files or areas updated:**

- `supabase/migrations/20260801210639_transaction_defaults.sql` — new `user_transaction_defaults` table (PK `user_id, type`), new `user_settings.default_transaction_type` column, the standard 4-policy RLS shape, `tg_set_user_id`/`tg_set_updated_at` triggers, a referential validation trigger, and a `reset_user_data` update.
- `apps/web-next/src/pages/settings/index.tsx` — new `TransactionDefaultsSection` and a "Transactions" tab; export `RangePicker` now takes presets.
- `apps/web-next/src/pages/transactions/create.tsx` — default date, default type, defaults prefill.
- `apps/web-next/src/pages/transactions/edit.tsx` — date-value fix and reuse of the shared category helpers.
- `apps/web-next/src/utility/{dateRanges,dayjsValue,categoryHierarchy}.ts`, `src/hooks/useTransactionDefaults.ts`, `src/styles/global.css`.
- `types.gen.ts` + `apps/web-next/src/types/database.types.ts` regenerated and synced.

**New functionality added:**

- Create form's Date defaults to today.
- Settings → Transactions tab: a default transaction Type, plus a grid of per-type default Category and Bank Account. All clearable, each saving on change.
- Create form pre-fills Type, Category and Bank Account from those defaults.
- Export range presets: This month, Last month, Last 3 months, Last 12 months, This year, Last year.

**Existing behavior changed:**

- Changing Type on the Create form now clears **Bank Account** as well as Category, so both re-derive from the newly selected type's defaults. Previously only Category was cleared.
- Typing over an existing date on the Create/Edit forms now reliably sticks — see Key Decisions.

## Key Decisions

**Decision:** Store the defaults in a dedicated preferences table rather than as `is_default` flags on `categories` / `bank_accounts`.
**Reasoning:** Keeps preference data out of the domain tables, so the bulk-upload, export and reset payload shapes are untouched. It also matches the existing `user_settings`/currency precedent.
**Alternatives considered:** Inline "default" star toggles on the Categories and Bank Accounts list pages. Categories are type-scoped in the UI so that would have worked there, but `bank-accounts/list.tsx` is a bare generic `ResourceList` with no type dimension to hang a per-type default off — it could only ever have expressed a single global default account.

**Decision:** Validate references with a trigger named `validate_user_transaction_defaults_refs`, not `check_*`.
**Reasoning:** Postgres fires same-timing triggers in alphabetical order. The validation must run *after* `set_user_id_on_user_transaction_defaults` or it reads a null `NEW.user_id` on insert. `validate_` sorts after `set_`; a `check_` name would sort before it and break. Noted in a comment in the migration.

**Decision:** Validate ownership/type/liveness in a trigger even though FKs exist.
**Reasoning:** The FKs guarantee the rows exist but not that they belong to this user, that the category's `type` matches the row's `type`, or that either is still live. `ON DELETE SET NULL` also never fires for this app's soft deletes. The trigger compares against `NEW.user_id` rather than `auth.uid()`, following the existing `check_transaction_bank_account` idiom.

**Decision:** Extract `toDayjs()` and use it in `getValueProps` on both transaction forms.
**Reasoning:** `dayjs(value)` returns a new instance on every render. rc-picker reads a new `value` identity as an external change and throws away text the user is part-way through typing, so a date silently reverted whenever a background query resolved mid-entry. This was pre-existing but latent; the two new queries this PR adds widened the window enough that several existing tests began failing intermittently. `toDayjs()` returns the same instance when the value is already a Dayjs.

**Decision:** Freeze the Create form's `initialValues` at mount via a `useState` initialiser, and apply the default Type through an effect instead.
**Reasoning:** A `useMemo` that recomputes produces a fresh `dayjs()`, and antd re-seeds the field from the new object — same class of bug as above. The default Type can't live in `initialValues` anyway, since it resolves asynchronously.

## How This Affects the System

- **User-facing changes:** Create form opens pre-filled; new Settings → Transactions tab (Settings now has four tabs); export presets. Switching Type on Create clears Bank Account as well as Category.
- **API changes:** None. `reset_user_data`'s return shape is deliberately unchanged, so the Settings UI needed no edit — it now also clears the entry defaults, which are not counted in the result.
- **Performance implications:** Two additional small RLS-scoped queries on the Create form and the Settings page (`user_transaction_defaults`, `user_settings`), both `pagination: off` over at most three rows.
- **Database changes:** One new table (`user_transaction_defaults`), one new nullable column (`user_settings.default_transaction_type`), one new trigger function, `reset_user_data` replaced. Additive and backwards compatible — a user with no defaults set sees exactly the previous behaviour apart from the pre-filled date.
- **Breaking changes:** None.

## Testing

**New tests added:**

- `supabase/tests/user_transaction_defaults_rls_test.sql` — 16 assertions: trigger-populated `user_id`, upsert on the `(user_id, type)` conflict target, clearing back to NULL, rejection of a type-mismatched category, a soft-deleted category, a soft-deleted bank account, another user's category and another user's bank account, RLS isolation both ways, and `reset_user_data` clearing both the defaults rows and the default type while leaving another user's untouched.
- `apps/web-next/e2e/tests/transaction-defaults.spec.ts` — 8 tests: the four-tab layout and per-type rows, category options scoped to their row's type, persistence across reload, clearing a default, full Create prefill via the no-`?type=` entry point, Type switching swapping both defaults, a manual bank-account pick not being overwritten, and a soft-deleted default rendering as empty rather than a raw UUID.

**Existing tests status:** All green. `supabase test db` — 275 tests across 18 files. `npm run test:e2e:ci` — 118 tests, run twice to check for flakiness.

**Manual testing performed:** Verified the date-commit behaviour directly in the browser via a temporary probe spec (removed before commit) — confirmed the Create form reverted a typed date before the fix and holds it after, and that the Edit form was unaffected.

**Edge cases tested:** Soft-deleted category/bank account referenced by a stored default (rejected at write time by the trigger, ignored at read time by the UI); cross-user references; category/type mismatch; a user with no defaults set at all (Create behaves as before); clearing a previously set default.

**Test files modified or added:**

- Added: `supabase/tests/user_transaction_defaults_rls_test.sql`, `apps/web-next/e2e/tests/transaction-defaults.spec.ts`
- Modified: `apps/web-next/e2e/tests/settings-tabs.spec.ts` (three tabs → four), `apps/web-next/e2e/tests/transactions-export.spec.ts` (preset fills both dates and enables Export)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
