### PR TITLE
chore(ci): pin Supabase CLI version instead of always using latest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,8 @@ jobs:
 
       - uses: supabase/setup-cli@v1
         with:
-          version: latest
+          # Pinned, not "latest" — see .github/workflows/playwright.yml for why.
+          version: 2.109.1
 
       - name: Start Supabase local development setup
         run: supabase db start

--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -23,7 +23,8 @@ jobs:
 
       - uses: supabase/setup-cli@v1
         with:
-          version: latest
+          # Pinned, not "latest" — see .github/workflows/playwright.yml for why.
+          version: 2.109.1
 
       - run: supabase link --project-ref $SUPABASE_PROJECT_ID
       - run: supabase db push

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -23,7 +23,8 @@ jobs:
 
       - uses: supabase/setup-cli@v1
         with:
-          version: latest
+          # Pinned, not "latest" — see .github/workflows/playwright.yml for why.
+          version: 2.109.1
 
       - run: supabase link --project-ref $SUPABASE_PROJECT_ID
       - run: supabase db push

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -31,7 +31,12 @@ jobs:
     - name: Install Supabase CLI
       uses: supabase/setup-cli@v1
       with:
-        version: latest
+        # Pinned, not "latest": a recent Supabase CLI release broke `supabase
+        # link`/`db push` against the platform API (the CLI's own response
+        # schema rejects a timestamp field Supabase's API returns), which took
+        # down every workflow using "latest" simultaneously with no code
+        # change on our side. Bump deliberately, not automatically.
+        version: 2.109.1
 
     - name: Push pending migrations to staging
       working-directory: ${{ github.workspace }}


### PR DESCRIPTION
## Why

CI failed on PR #264 with:

```
failed to get api keys: SchemaError(Expected a string matching the RegExp ...
  at [2]["inserted_at"])
```

This happens inside `supabase link`, which `.github/workflows/playwright.yml`'s "Push pending migrations to staging" step runs before any Playwright test executes. It's unrelated to #264's content (a test-only timeout fix) — confirmed by re-running the exact same failed job, which failed identically, and by checking history: the same workflow succeeded at 04:30 UTC today and has failed on every attempt since.

## What Changed

All four workflows using `supabase/setup-cli@v1` (`playwright.yml`, `deploy-staging.yaml`, `deploy-production.yaml`, `ci.yaml`) installed `version: latest`, so every run pulls whatever the newest published CLI build is at that moment. A recent Supabase CLI release broke `supabase link`/`supabase db push` against the platform API: the CLI's own response-schema validation rejects a timestamp field (`inserted_at`) that Supabase's API is returning, so the CLI fails before it even gets to push migrations — nothing to do with our migration content.

- Files or areas updated: `.github/workflows/playwright.yml`, `.github/workflows/deploy-staging.yaml`, `.github/workflows/deploy-production.yaml`, `.github/workflows/ci.yaml`
- New functionality added: none
- Existing behavior changed: Supabase CLI version is now pinned to `2.109.1` instead of always resolving to `latest`.

## Key Decisions

- Decision: Pin to `2.109.1` in all four workflows, including `ci.yaml`.
- Reasoning: `ci.yaml` only runs `supabase db start`/`db lint`/`gen types` locally and never calls `supabase link`, so it wasn't actually broken by this incident — but `latest` is demonstrably unsafe for a tool the pipeline depends on, and leaving one workflow unpinned would just mean the next CLI regression breaks it too, at a time no one's looking at this issue.
- Reasoning for `2.109.1` specifically: confirmed working locally throughout the session that found this bug (migrations, pgTAP tests, `gen types`), and it's published on npm (which is what `supabase/setup-cli@v1`'s `version` input resolves fixed versions from).
- Alternatives considered: waiting for Supabase to ship a fix and keep using `latest` — rejected, since it leaves every workflow that links a project (staging deploys, production deploys, this PR's own e2e run) unpredictably broken with no warning until it happens again.

## How This Affects the System

- User-facing changes: none
- API changes: none
- Performance implications: none
- Database changes: none
- Breaking changes: none — this restores the previously-working behavior; future CLI upgrades now require a deliberate version bump instead of happening silently.

## Testing

- New tests added: none (CI config change)
- Existing tests status: n/a until this merges and a workflow run exercises it
- Manual testing performed: confirmed `2.109.1` is published on npm and is the exact version already in use locally (`supabase --version`), which has run migrations, pgTAP tests, and type generation successfully throughout today's session
- Edge cases tested: n/a
- Test files modified or added: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
