### PR TITLE
feat(export): include bank accounts and tags in JSON export

### DIFF
--- a/apps/web-next/src/pages/settings/index.tsx
+++ b/apps/web-next/src/pages/settings/index.tsx
@@ -34,6 +34,7 @@ import {
   buildJsonExport,
   downloadJson,
   fetchTransactionsForExport,
+  fetchExportMetadata,
   getExportRangePresets,
   simpleLabelFilterOption,
   valueIfStillAvailable,
@@ -518,7 +519,18 @@ const ExportSection = () => {
       const csv = buildCsv(result.rows.map(transactionToCsvRow));
       downloadCsv(`transactions_${startDate}_to_${endDate}.csv`, csv);
     } else {
-      const json = buildJsonExport(result.rows);
+      const metadataResult = await fetchExportMetadata();
+      if (!metadataResult.ok) {
+        setError(metadataResult.message);
+        openNotification?.({
+          type: "error",
+          message: "Export failed",
+          description: metadataResult.message,
+        });
+        setIsExporting(false);
+        return;
+      }
+      const json = buildJsonExport(result.rows, metadataResult);
       downloadJson(`transactions_${startDate}_to_${endDate}.json`, json);
     }
 

--- a/apps/web-next/src/utility/exportMetadata.test.ts
+++ b/apps/web-next/src/utility/exportMetadata.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { fetchExportMetadata } from "./exportMetadata";
+
+function createSupabaseMock({
+  categories,
+  bankAccounts,
+  tags,
+  errorTable,
+}: {
+  categories?: unknown[];
+  bankAccounts?: unknown[];
+  tags?: unknown[];
+  errorTable?: string;
+}) {
+  const from = (table: string) => {
+    const data =
+      table === "categories_with_usage"
+        ? (categories ?? [])
+        : table === "bank_accounts_with_usage"
+          ? (bankAccounts ?? [])
+          : (tags ?? []);
+    const result =
+      table === errorTable
+        ? Promise.resolve({ data: null, error: { message: `${table} failed` } })
+        : Promise.resolve({ data, error: null });
+    return { select: () => result };
+  };
+  return { from } as unknown as SupabaseClient;
+}
+
+describe("fetchExportMetadata", () => {
+  it("returns categories, bank accounts, and tags from the *_with_usage views", async () => {
+    const client = createSupabaseMock({
+      categories: [
+        { type: "spend", name: "Groceries", description: null, parent_name: null },
+      ],
+      bankAccounts: [{ name: "AmEx", description: "Primary card" }],
+      tags: [{ name: "Marocco", description: null }],
+    });
+
+    const result = await fetchExportMetadata(client);
+
+    expect(result).toEqual({
+      ok: true,
+      categories: [
+        { type: "spend", name: "Groceries", description: null, parent_name: null },
+      ],
+      bank_accounts: [{ name: "AmEx", description: "Primary card" }],
+      tags: [{ name: "Marocco", description: null }],
+    });
+  });
+
+  it("filters out rows with a null name or type", async () => {
+    const client = createSupabaseMock({
+      categories: [
+        { type: "spend", name: "Groceries", description: null, parent_name: null },
+        { type: null, name: "Bad Row", description: null, parent_name: null },
+      ],
+      bankAccounts: [
+        { name: "AmEx", description: null },
+        { name: null, description: null },
+      ],
+      tags: [{ name: null, description: null }],
+    });
+
+    const result = await fetchExportMetadata(client);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.categories).toHaveLength(1);
+    expect(result.bank_accounts).toEqual([{ name: "AmEx", description: null }]);
+    expect(result.tags).toEqual([]);
+  });
+
+  it("surfaces an error when any query fails", async () => {
+    const client = createSupabaseMock({
+      categories: [],
+      bankAccounts: [],
+      tags: [],
+      errorTable: "tags_with_usage",
+    });
+
+    const result = await fetchExportMetadata(client);
+
+    expect(result).toEqual({ ok: false, message: "tags_with_usage failed" });
+  });
+});

--- a/apps/web-next/src/utility/exportMetadata.ts
+++ b/apps/web-next/src/utility/exportMetadata.ts
@@ -1,0 +1,61 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "../types/database.types";
+import { supabaseClient } from "./supabaseClient";
+
+export interface CategoryExportRecord {
+  type: Database["public"]["Enums"]["transaction_type"];
+  name: string;
+  description: string | null;
+  parent_name: string | null;
+}
+
+export interface BankAccountExportRecord {
+  name: string;
+  description: string | null;
+}
+
+export interface TagExportRecord {
+  name: string;
+  description: string | null;
+}
+
+export interface ExportMetadata {
+  categories: CategoryExportRecord[];
+  bank_accounts: BankAccountExportRecord[];
+  tags: TagExportRecord[];
+}
+
+export type ExportMetadataFetchResult =
+  | ({ ok: true } & ExportMetadata)
+  | { ok: false; message: string };
+
+// Views already scope rows to the current user via RLS (security_invoker) and
+// exclude soft-deleted records, so no extra filtering is needed here.
+export const fetchExportMetadata = async (
+  client: SupabaseClient = supabaseClient
+): Promise<ExportMetadataFetchResult> => {
+  const [categoriesRes, bankAccountsRes, tagsRes] = await Promise.all([
+    client
+      .from("categories_with_usage")
+      .select("type, name, description, parent_name"),
+    client.from("bank_accounts_with_usage").select("name, description"),
+    client.from("tags_with_usage").select("name, description"),
+  ]);
+
+  const error = categoriesRes.error ?? bankAccountsRes.error ?? tagsRes.error;
+  if (error) return { ok: false, message: error.message };
+
+  return {
+    ok: true,
+    // Columns are nullable at the view-type level only because it's a view;
+    // RLS guarantees these belong to the current user and name/type are
+    // NOT NULL on the underlying tables, so filtering here is just a type guard.
+    categories: (categoriesRes.data ?? []).filter(
+      (row): row is CategoryExportRecord => row.name !== null && row.type !== null
+    ),
+    bank_accounts: (bankAccountsRes.data ?? []).filter(
+      (row): row is BankAccountExportRecord => row.name !== null
+    ),
+    tags: (tagsRes.data ?? []).filter((row): row is TagExportRecord => row.name !== null),
+  };
+};

--- a/apps/web-next/src/utility/index.ts
+++ b/apps/web-next/src/utility/index.ts
@@ -11,5 +11,6 @@ export * from "./userSettings";
 export * from "./datePickerFormats";
 export * from "./csvExport";
 export * from "./exportTransactions";
+export * from "./exportMetadata";
 export * from "./jsonExport";
 export * from "./fileDownload";

--- a/apps/web-next/src/utility/jsonExport.test.ts
+++ b/apps/web-next/src/utility/jsonExport.test.ts
@@ -2,11 +2,17 @@ import { describe, expect, it } from "vitest";
 import {
   transactionToJsonExportRow,
   buildJsonExport,
-  collectJsonExportCategories,
-  collectJsonExportBankAccounts,
-  collectJsonExportTags,
+  categoryRecordToJsonExportCategory,
+  bankAccountRecordToJsonExportBankAccount,
+  tagRecordToJsonExportTag,
 } from "./jsonExport";
 import type { TransactionExportRow } from "./exportTransactions";
+import type {
+  CategoryExportRecord,
+  BankAccountExportRecord,
+  TagExportRecord,
+  ExportMetadata,
+} from "./exportMetadata";
 
 describe("transactionToJsonExportRow", () => {
   const base: TransactionExportRow = {
@@ -81,20 +87,101 @@ describe("transactionToJsonExportRow", () => {
   });
 });
 
+describe("categoryRecordToJsonExportCategory", () => {
+  it("omits parent and description when absent", () => {
+    const record: CategoryExportRecord = {
+      type: "spend",
+      name: "Groceries",
+      description: null,
+      parent_name: null,
+    };
+    expect(categoryRecordToJsonExportCategory(record)).toEqual({
+      type: "spend",
+      name: "Groceries",
+    });
+  });
+
+  it("includes parent and description when present", () => {
+    const record: CategoryExportRecord = {
+      type: "spend",
+      name: "Eating out",
+      description: "Vacation dining",
+      parent_name: "Vacation",
+    };
+    expect(categoryRecordToJsonExportCategory(record)).toEqual({
+      type: "spend",
+      name: "Eating out",
+      parent: "Vacation",
+      description: "Vacation dining",
+    });
+  });
+});
+
+describe("bankAccountRecordToJsonExportBankAccount", () => {
+  it("omits description when absent", () => {
+    const record: BankAccountExportRecord = { name: "AmEx", description: null };
+    expect(bankAccountRecordToJsonExportBankAccount(record)).toEqual({ name: "AmEx" });
+  });
+
+  it("includes description when present", () => {
+    const record: BankAccountExportRecord = {
+      name: "AmEx",
+      description: "Primary credit card",
+    };
+    expect(bankAccountRecordToJsonExportBankAccount(record)).toEqual({
+      name: "AmEx",
+      description: "Primary credit card",
+    });
+  });
+});
+
+describe("tagRecordToJsonExportTag", () => {
+  it("omits description when absent", () => {
+    const record: TagExportRecord = { name: "Marocco", description: null };
+    expect(tagRecordToJsonExportTag(record)).toEqual({ name: "Marocco" });
+  });
+
+  it("includes description when present", () => {
+    const record: TagExportRecord = {
+      name: "Marocco",
+      description: "2025 trip",
+    };
+    expect(tagRecordToJsonExportTag(record)).toEqual({
+      name: "Marocco",
+      description: "2025 trip",
+    });
+  });
+});
+
 describe("buildJsonExport", () => {
-  it("wraps rows in a { categories, transactions } object matching BulkUploadPayload", () => {
-    const json = buildJsonExport([
-      {
-        date: "2026-07-01",
-        type: "spend",
-        category_name: "Eating out",
-        category_parent_name: "Food",
-        bank_account_name: "Chase Checking",
-        amount: 12.34,
-        tag_names: ["groceries", "urgent"],
-        notes: "Weekly shopping",
-      },
-    ]);
+  const emptyMetadata: ExportMetadata = { categories: [], bank_accounts: [], tags: [] };
+
+  it("wraps rows and metadata in a { categories, bank_accounts, tags, transactions } object matching BulkUploadPayload", () => {
+    const metadata: ExportMetadata = {
+      categories: [
+        { type: "spend", name: "Eating out", description: null, parent_name: "Food" },
+      ],
+      bank_accounts: [{ name: "Chase Checking", description: null }],
+      tags: [
+        { name: "groceries", description: null },
+        { name: "urgent", description: null },
+      ],
+    };
+    const json = buildJsonExport(
+      [
+        {
+          date: "2026-07-01",
+          type: "spend",
+          category_name: "Eating out",
+          category_parent_name: "Food",
+          bank_account_name: "Chase Checking",
+          amount: 12.34,
+          tag_names: ["groceries", "urgent"],
+          notes: "Weekly shopping",
+        },
+      ],
+      metadata
+    );
     expect(JSON.parse(json)).toEqual({
       categories: [{ type: "spend", name: "Eating out", parent: "Food" }],
       bank_accounts: [{ name: "Chase Checking" }],
@@ -113,159 +200,62 @@ describe("buildJsonExport", () => {
     });
   });
 
-  it("pretty-prints with 2-space indentation", () => {
-    const json = buildJsonExport([]);
-    expect(json).toBe(
-      '{\n  "categories": [],\n  "bank_accounts": [],\n  "tags": [],\n  "transactions": []\n}'
-    );
-  });
-});
-
-describe("collectJsonExportCategories", () => {
-  const base: TransactionExportRow = {
-    date: "2026-07-01",
-    type: "spend",
-    category_name: null,
-    category_parent_name: null,
-    bank_account_name: null,
-    amount: 12.34,
-    tag_names: [],
-    notes: null,
-  };
-
-  it("emits a bare { type, name } for a root-level category", () => {
-    const categories = collectJsonExportCategories([
-      { ...base, category_name: "Salary", type: "earn" },
-    ]);
-    expect(categories).toEqual([{ type: "earn", name: "Salary" }]);
-  });
-
-  it("includes parent for a nested category", () => {
-    const categories = collectJsonExportCategories([
-      { ...base, category_name: "Eating out", category_parent_name: "Food" },
-    ]);
-    expect(categories).toEqual([
-      { type: "spend", name: "Eating out", parent: "Food" },
-    ]);
-  });
-
-  it("skips rows with no category", () => {
-    const categories = collectJsonExportCategories([base]);
-    expect(categories).toEqual([]);
-  });
-
-  it("dedupes repeated (type, parent, name) triples across rows", () => {
-    const categories = collectJsonExportCategories([
-      { ...base, category_name: "Eating out", category_parent_name: "Food" },
-      { ...base, category_name: "Eating out", category_parent_name: "Food" },
-    ]);
-    expect(categories).toHaveLength(1);
-  });
-
-  it("treats the same leaf name under different parents as distinct categories", () => {
-    const categories = collectJsonExportCategories([
-      { ...base, category_name: "Other", category_parent_name: "Food" },
-      { ...base, category_name: "Other", category_parent_name: "Transport" },
-    ]);
-    expect(categories).toEqual([
-      { type: "spend", name: "Other", parent: "Food" },
-      { type: "spend", name: "Other", parent: "Transport" },
-    ]);
-  });
-
-  it("keeps categories distinct when a name contains the key separator", () => {
-    const categories = collectJsonExportCategories([
-      { ...base, category_name: "X", category_parent_name: "Food::Sub" },
-      { ...base, category_name: "Sub::X", category_parent_name: "Food" },
-    ]);
-    expect(categories).toHaveLength(2);
-    expect(categories).toContainEqual({
-      type: "spend",
-      name: "X",
-      parent: "Food::Sub",
-    });
-    expect(categories).toContainEqual({
-      type: "spend",
-      name: "Sub::X",
-      parent: "Food",
+  it("includes the full metadata library even when nothing appears on an exported transaction", () => {
+    const metadata: ExportMetadata = {
+      categories: [{ type: "earn", name: "Salary", description: null, parent_name: null }],
+      bank_accounts: [{ name: "Unused Account", description: null }],
+      tags: [{ name: "unused-tag", description: null }],
+    };
+    const json = buildJsonExport([], metadata);
+    expect(JSON.parse(json)).toEqual({
+      categories: [{ type: "earn", name: "Salary" }],
+      bank_accounts: [{ name: "Unused Account" }],
+      tags: [{ name: "unused-tag" }],
+      transactions: [],
     });
   });
 
-  it("sorts deterministically by type, then parent, then name", () => {
-    const categories = collectJsonExportCategories([
-      { ...base, category_name: "Groceries" },
-      { ...base, category_name: "Eating out", category_parent_name: "Food" },
-      { ...base, category_name: "Salary", type: "earn" },
-      { ...base, category_name: "Taxi", category_parent_name: "Transport" },
-    ]);
-    expect(categories).toEqual([
+  it("sorts categories by type, then parent, then name", () => {
+    const metadata: ExportMetadata = {
+      categories: [
+        { type: "spend", name: "Taxi", description: null, parent_name: "Transport" },
+        { type: "spend", name: "Groceries", description: null, parent_name: null },
+        { type: "earn", name: "Salary", description: null, parent_name: null },
+        { type: "spend", name: "Eating out", description: null, parent_name: "Food" },
+      ],
+      bank_accounts: [],
+      tags: [],
+    };
+    const json = buildJsonExport([], metadata);
+    expect(JSON.parse(json).categories).toEqual([
       { type: "earn", name: "Salary" },
       { type: "spend", name: "Groceries" },
       { type: "spend", name: "Eating out", parent: "Food" },
       { type: "spend", name: "Taxi", parent: "Transport" },
     ]);
   });
-});
 
-describe("collectJsonExportBankAccounts", () => {
-  const base: TransactionExportRow = {
-    date: "2026-07-01",
-    type: "spend",
-    category_name: null,
-    category_parent_name: null,
-    bank_account_name: null,
-    amount: 12.34,
-    tag_names: [],
-    notes: null,
-  };
-
-  it("skips rows with no bank account", () => {
-    expect(collectJsonExportBankAccounts([base])).toEqual([]);
+  it("sorts bank_accounts and tags alphabetically by name", () => {
+    const metadata: ExportMetadata = {
+      categories: [],
+      bank_accounts: [
+        { name: "Wise", description: null },
+        { name: "AmEx", description: null },
+      ],
+      tags: [
+        { name: "Wise", description: null },
+        { name: "AmEx", description: null },
+      ],
+    };
+    const json = buildJsonExport([], metadata);
+    expect(JSON.parse(json).bank_accounts).toEqual([{ name: "AmEx" }, { name: "Wise" }]);
+    expect(JSON.parse(json).tags).toEqual([{ name: "AmEx" }, { name: "Wise" }]);
   });
 
-  it("dedupes repeated bank account names across rows", () => {
-    const accounts = collectJsonExportBankAccounts([
-      { ...base, bank_account_name: "Chase Checking" },
-      { ...base, bank_account_name: "Chase Checking" },
-    ]);
-    expect(accounts).toEqual([{ name: "Chase Checking" }]);
-  });
-
-  it("sorts alphabetically by name", () => {
-    const accounts = collectJsonExportBankAccounts([
-      { ...base, bank_account_name: "Wise" },
-      { ...base, bank_account_name: "AmEx" },
-    ]);
-    expect(accounts).toEqual([{ name: "AmEx" }, { name: "Wise" }]);
-  });
-});
-
-describe("collectJsonExportTags", () => {
-  const base: TransactionExportRow = {
-    date: "2026-07-01",
-    type: "spend",
-    category_name: null,
-    category_parent_name: null,
-    bank_account_name: null,
-    amount: 12.34,
-    tag_names: [],
-    notes: null,
-  };
-
-  it("skips rows with no tags", () => {
-    expect(collectJsonExportTags([base])).toEqual([]);
-  });
-
-  it("dedupes repeated tag names across rows", () => {
-    const tags = collectJsonExportTags([
-      { ...base, tag_names: ["urgent", "groceries"] },
-      { ...base, tag_names: ["urgent"] },
-    ]);
-    expect(tags).toEqual([{ name: "groceries" }, { name: "urgent" }]);
-  });
-
-  it("sorts alphabetically by name", () => {
-    const tags = collectJsonExportTags([{ ...base, tag_names: ["Wise", "AmEx"] }]);
-    expect(tags).toEqual([{ name: "AmEx" }, { name: "Wise" }]);
+  it("pretty-prints with 2-space indentation", () => {
+    const json = buildJsonExport([], emptyMetadata);
+    expect(json).toBe(
+      '{\n  "categories": [],\n  "bank_accounts": [],\n  "tags": [],\n  "transactions": []\n}'
+    );
   });
 });

--- a/apps/web-next/src/utility/jsonExport.test.ts
+++ b/apps/web-next/src/utility/jsonExport.test.ts
@@ -115,6 +115,20 @@ describe("categoryRecordToJsonExportCategory", () => {
       description: "Vacation dining",
     });
   });
+
+  it("preserves an empty-string description rather than treating it as absent", () => {
+    const record: CategoryExportRecord = {
+      type: "spend",
+      name: "Groceries",
+      description: "",
+      parent_name: null,
+    };
+    expect(categoryRecordToJsonExportCategory(record)).toEqual({
+      type: "spend",
+      name: "Groceries",
+      description: "",
+    });
+  });
 });
 
 describe("bankAccountRecordToJsonExportBankAccount", () => {
@@ -131,6 +145,14 @@ describe("bankAccountRecordToJsonExportBankAccount", () => {
     expect(bankAccountRecordToJsonExportBankAccount(record)).toEqual({
       name: "AmEx",
       description: "Primary credit card",
+    });
+  });
+
+  it("preserves an empty-string description rather than treating it as absent", () => {
+    const record: BankAccountExportRecord = { name: "AmEx", description: "" };
+    expect(bankAccountRecordToJsonExportBankAccount(record)).toEqual({
+      name: "AmEx",
+      description: "",
     });
   });
 });
@@ -257,5 +279,58 @@ describe("buildJsonExport", () => {
     expect(json).toBe(
       '{\n  "categories": [],\n  "bank_accounts": [],\n  "tags": [],\n  "transactions": []\n}'
     );
+  });
+
+  it("adds a category/bank_account/tag referenced by a transaction but absent from the metadata library (e.g. soft-deleted), so the file can still re-import", () => {
+    const row: TransactionExportRow = {
+      date: "2026-07-01",
+      type: "spend",
+      category_name: "Side Gig",
+      category_parent_name: null,
+      bank_account_name: "Closed Account",
+      amount: 12.34,
+      tag_names: ["retired-tag"],
+      notes: null,
+    };
+    const json = buildJsonExport([row], emptyMetadata);
+    expect(JSON.parse(json)).toEqual({
+      categories: [{ type: "spend", name: "Side Gig" }],
+      bank_accounts: [{ name: "Closed Account" }],
+      tags: [{ name: "retired-tag" }],
+      transactions: [
+        {
+          date: "2026-07-01",
+          type: "spend",
+          amount: 12.34,
+          category: "Side Gig",
+          bank_account: "Closed Account",
+          tags: ["retired-tag"],
+        },
+      ],
+    });
+  });
+
+  it("prefers the metadata library's description over a bare row-derived entry for the same category", () => {
+    const metadata: ExportMetadata = {
+      categories: [
+        { type: "spend", name: "Groceries", description: "Food", parent_name: null },
+      ],
+      bank_accounts: [],
+      tags: [],
+    };
+    const row: TransactionExportRow = {
+      date: "2026-07-01",
+      type: "spend",
+      category_name: "Groceries",
+      category_parent_name: null,
+      bank_account_name: null,
+      amount: 12.34,
+      tag_names: [],
+      notes: null,
+    };
+    const json = buildJsonExport([row], metadata);
+    expect(JSON.parse(json).categories).toEqual([
+      { type: "spend", name: "Groceries", description: "Food" },
+    ]);
   });
 });

--- a/apps/web-next/src/utility/jsonExport.test.ts
+++ b/apps/web-next/src/utility/jsonExport.test.ts
@@ -3,6 +3,8 @@ import {
   transactionToJsonExportRow,
   buildJsonExport,
   collectJsonExportCategories,
+  collectJsonExportBankAccounts,
+  collectJsonExportTags,
 } from "./jsonExport";
 import type { TransactionExportRow } from "./exportTransactions";
 
@@ -95,6 +97,8 @@ describe("buildJsonExport", () => {
     ]);
     expect(JSON.parse(json)).toEqual({
       categories: [{ type: "spend", name: "Eating out", parent: "Food" }],
+      bank_accounts: [{ name: "Chase Checking" }],
+      tags: [{ name: "groceries" }, { name: "urgent" }],
       transactions: [
         {
           date: "2026-07-01",
@@ -111,7 +115,9 @@ describe("buildJsonExport", () => {
 
   it("pretty-prints with 2-space indentation", () => {
     const json = buildJsonExport([]);
-    expect(json).toBe('{\n  "categories": [],\n  "transactions": []\n}');
+    expect(json).toBe(
+      '{\n  "categories": [],\n  "bank_accounts": [],\n  "tags": [],\n  "transactions": []\n}'
+    );
   });
 });
 
@@ -198,5 +204,68 @@ describe("collectJsonExportCategories", () => {
       { type: "spend", name: "Eating out", parent: "Food" },
       { type: "spend", name: "Taxi", parent: "Transport" },
     ]);
+  });
+});
+
+describe("collectJsonExportBankAccounts", () => {
+  const base: TransactionExportRow = {
+    date: "2026-07-01",
+    type: "spend",
+    category_name: null,
+    category_parent_name: null,
+    bank_account_name: null,
+    amount: 12.34,
+    tag_names: [],
+    notes: null,
+  };
+
+  it("skips rows with no bank account", () => {
+    expect(collectJsonExportBankAccounts([base])).toEqual([]);
+  });
+
+  it("dedupes repeated bank account names across rows", () => {
+    const accounts = collectJsonExportBankAccounts([
+      { ...base, bank_account_name: "Chase Checking" },
+      { ...base, bank_account_name: "Chase Checking" },
+    ]);
+    expect(accounts).toEqual([{ name: "Chase Checking" }]);
+  });
+
+  it("sorts alphabetically by name", () => {
+    const accounts = collectJsonExportBankAccounts([
+      { ...base, bank_account_name: "Wise" },
+      { ...base, bank_account_name: "AmEx" },
+    ]);
+    expect(accounts).toEqual([{ name: "AmEx" }, { name: "Wise" }]);
+  });
+});
+
+describe("collectJsonExportTags", () => {
+  const base: TransactionExportRow = {
+    date: "2026-07-01",
+    type: "spend",
+    category_name: null,
+    category_parent_name: null,
+    bank_account_name: null,
+    amount: 12.34,
+    tag_names: [],
+    notes: null,
+  };
+
+  it("skips rows with no tags", () => {
+    expect(collectJsonExportTags([base])).toEqual([]);
+  });
+
+  it("dedupes repeated tag names across rows", () => {
+    const tags = collectJsonExportTags([
+      { ...base, tag_names: ["urgent", "groceries"] },
+      { ...base, tag_names: ["urgent"] },
+    ]);
+    expect(tags).toEqual([{ name: "groceries" }, { name: "urgent" }]);
+  });
+
+  it("sorts alphabetically by name", () => {
+    const tags = collectJsonExportTags([{ ...base, tag_names: ["Wise", "AmEx"] }]);
+    expect(tags).toEqual([{ name: "AmEx" }, { name: "Wise" }]);
   });
 });

--- a/apps/web-next/src/utility/jsonExport.ts
+++ b/apps/web-next/src/utility/jsonExport.ts
@@ -19,8 +19,18 @@ export interface JsonExportCategory {
   parent?: string;
 }
 
+export interface JsonExportBankAccount {
+  name: string;
+}
+
+export interface JsonExportTag {
+  name: string;
+}
+
 export interface JsonExportPayload {
   categories: JsonExportCategory[];
+  bank_accounts: JsonExportBankAccount[];
+  tags: JsonExportTag[];
   transactions: JsonExportTransaction[];
 }
 
@@ -73,9 +83,29 @@ export const collectJsonExportCategories = (
   });
 };
 
+export const collectJsonExportBankAccounts = (
+  rows: TransactionExportRow[]
+): JsonExportBankAccount[] => {
+  const names = new Set<string>();
+  for (const row of rows) {
+    if (row.bank_account_name) names.add(row.bank_account_name);
+  }
+  return [...names].sort((a, b) => a.localeCompare(b)).map((name) => ({ name }));
+};
+
+export const collectJsonExportTags = (rows: TransactionExportRow[]): JsonExportTag[] => {
+  const names = new Set<string>();
+  for (const row of rows) {
+    for (const name of row.tag_names) names.add(name);
+  }
+  return [...names].sort((a, b) => a.localeCompare(b)).map((name) => ({ name }));
+};
+
 export const buildJsonExport = (rows: TransactionExportRow[]): string => {
   const payload: JsonExportPayload = {
     categories: collectJsonExportCategories(rows),
+    bank_accounts: collectJsonExportBankAccounts(rows),
+    tags: collectJsonExportTags(rows),
     transactions: rows.map(transactionToJsonExportRow),
   };
   return JSON.stringify(payload, null, 2);

--- a/apps/web-next/src/utility/jsonExport.ts
+++ b/apps/web-next/src/utility/jsonExport.ts
@@ -83,23 +83,25 @@ export const collectJsonExportCategories = (
   });
 };
 
-export const collectJsonExportBankAccounts = (
-  rows: TransactionExportRow[]
-): JsonExportBankAccount[] => {
+const collectUniqueNames = (
+  rows: TransactionExportRow[],
+  getNames: (row: TransactionExportRow) => Iterable<string | null | undefined>
+): { name: string }[] => {
   const names = new Set<string>();
   for (const row of rows) {
-    if (row.bank_account_name) names.add(row.bank_account_name);
+    for (const name of getNames(row)) {
+      if (name) names.add(name);
+    }
   }
   return [...names].sort((a, b) => a.localeCompare(b)).map((name) => ({ name }));
 };
 
-export const collectJsonExportTags = (rows: TransactionExportRow[]): JsonExportTag[] => {
-  const names = new Set<string>();
-  for (const row of rows) {
-    for (const name of row.tag_names) names.add(name);
-  }
-  return [...names].sort((a, b) => a.localeCompare(b)).map((name) => ({ name }));
-};
+export const collectJsonExportBankAccounts = (
+  rows: TransactionExportRow[]
+): JsonExportBankAccount[] => collectUniqueNames(rows, (row) => [row.bank_account_name]);
+
+export const collectJsonExportTags = (rows: TransactionExportRow[]): JsonExportTag[] =>
+  collectUniqueNames(rows, (row) => row.tag_names);
 
 export const buildJsonExport = (rows: TransactionExportRow[]): string => {
   const payload: JsonExportPayload = {

--- a/apps/web-next/src/utility/jsonExport.ts
+++ b/apps/web-next/src/utility/jsonExport.ts
@@ -62,27 +62,72 @@ export const transactionToJsonExportRow = (
   return result;
 };
 
+// A missing description is `null` (never `""`), so this only omits the key
+// when there truly isn't one — an empty-string description is preserved.
+const withOptionalDescription = <T extends object>(
+  base: T,
+  description: string | null
+): T & { description?: string } =>
+  description !== null ? { ...base, description } : base;
+
 export const categoryRecordToJsonExportCategory = (
   record: CategoryExportRecord
 ): JsonExportCategory => {
-  const result: JsonExportCategory = { type: record.type, name: record.name };
-  if (record.parent_name) result.parent = record.parent_name;
-  if (record.description) result.description = record.description;
-  return result;
+  const base: JsonExportCategory = { type: record.type, name: record.name };
+  if (record.parent_name !== null) base.parent = record.parent_name;
+  return withOptionalDescription(base, record.description);
 };
 
 export const bankAccountRecordToJsonExportBankAccount = (
   record: BankAccountExportRecord
-): JsonExportBankAccount => {
-  const result: JsonExportBankAccount = { name: record.name };
-  if (record.description) result.description = record.description;
-  return result;
+): JsonExportBankAccount => withOptionalDescription({ name: record.name }, record.description);
+
+export const tagRecordToJsonExportTag = (record: TagExportRecord): JsonExportTag =>
+  withOptionalDescription({ name: record.name }, record.description);
+
+const categoryKey = (category: Pick<JsonExportCategory, "type" | "parent" | "name">): string =>
+  JSON.stringify([category.type, category.parent ?? null, category.name]);
+
+// categories_with_usage/bank_accounts_with_usage/tags_with_usage only list
+// non-deleted records, but transactions_with_details still resolves the name
+// of a soft-deleted category/bank account/tag on a transaction that used it
+// before the delete. Without this, an export could drop an entity that a
+// transaction in the very same file still references, producing a JSON file
+// that fails to re-import. These referenced-but-deleted entries are added
+// with no description, since the source record is gone.
+const collectReferencedCategories = (rows: TransactionExportRow[]): JsonExportCategory[] => {
+  const seen = new Map<string, JsonExportCategory>();
+  for (const row of rows) {
+    if (!row.category_name) continue;
+    const category: JsonExportCategory = row.category_parent_name
+      ? { type: row.type, name: row.category_name, parent: row.category_parent_name }
+      : { type: row.type, name: row.category_name };
+    seen.set(categoryKey(category), category);
+  }
+  return [...seen.values()];
 };
 
-export const tagRecordToJsonExportTag = (record: TagExportRecord): JsonExportTag => {
-  const result: JsonExportTag = { name: record.name };
-  if (record.description) result.description = record.description;
-  return result;
+const collectReferencedNames = (
+  rows: TransactionExportRow[],
+  getNames: (row: TransactionExportRow) => Iterable<string | null | undefined>
+): string[] => {
+  const names = new Set<string>();
+  for (const row of rows) {
+    for (const name of getNames(row)) {
+      if (name) names.add(name);
+    }
+  }
+  return [...names];
+};
+
+const mergeUnique = <T>(primary: T[], fallback: T[], keyOf: (item: T) => string): T[] => {
+  const merged = new Map<string, T>();
+  for (const item of primary) merged.set(keyOf(item), item);
+  for (const item of fallback) {
+    const key = keyOf(item);
+    if (!merged.has(key)) merged.set(key, item);
+  }
+  return [...merged.values()];
 };
 
 const sortJsonExportCategories = (
@@ -101,14 +146,26 @@ export const buildJsonExport = (
   rows: TransactionExportRow[],
   metadata: ExportMetadata
 ): string => {
+  const categories = mergeUnique(
+    metadata.categories.map(categoryRecordToJsonExportCategory),
+    collectReferencedCategories(rows),
+    categoryKey
+  );
+  const bankAccounts = mergeUnique(
+    metadata.bank_accounts.map(bankAccountRecordToJsonExportBankAccount),
+    collectReferencedNames(rows, (row) => [row.bank_account_name]).map((name) => ({ name })),
+    (account) => account.name
+  );
+  const tags = mergeUnique(
+    metadata.tags.map(tagRecordToJsonExportTag),
+    collectReferencedNames(rows, (row) => row.tag_names).map((name) => ({ name })),
+    (tag) => tag.name
+  );
+
   const payload: JsonExportPayload = {
-    categories: sortJsonExportCategories(
-      metadata.categories.map(categoryRecordToJsonExportCategory)
-    ),
-    bank_accounts: sortByName(
-      metadata.bank_accounts.map(bankAccountRecordToJsonExportBankAccount)
-    ),
-    tags: sortByName(metadata.tags.map(tagRecordToJsonExportTag)),
+    categories: sortJsonExportCategories(categories),
+    bank_accounts: sortByName(bankAccounts),
+    tags: sortByName(tags),
     transactions: rows.map(transactionToJsonExportRow),
   };
   return JSON.stringify(payload, null, 2);

--- a/apps/web-next/src/utility/jsonExport.ts
+++ b/apps/web-next/src/utility/jsonExport.ts
@@ -1,5 +1,11 @@
 import type { Database } from "../types/database.types";
 import type { TransactionExportRow } from "./exportTransactions";
+import type {
+  BankAccountExportRecord,
+  CategoryExportRecord,
+  ExportMetadata,
+  TagExportRecord,
+} from "./exportMetadata";
 import { formatCategoryPath } from "./csvExport";
 import { downloadTextFile } from "./fileDownload";
 
@@ -16,15 +22,18 @@ export interface JsonExportTransaction {
 export interface JsonExportCategory {
   type: Database["public"]["Enums"]["transaction_type"];
   name: string;
+  description?: string;
   parent?: string;
 }
 
 export interface JsonExportBankAccount {
   name: string;
+  description?: string;
 }
 
 export interface JsonExportTag {
   name: string;
+  description?: string;
 }
 
 export interface JsonExportPayload {
@@ -53,61 +62,53 @@ export const transactionToJsonExportRow = (
   return result;
 };
 
-export const collectJsonExportCategories = (
-  rows: TransactionExportRow[]
-): JsonExportCategory[] => {
-  const seen = new Map<string, JsonExportCategory>();
+export const categoryRecordToJsonExportCategory = (
+  record: CategoryExportRecord
+): JsonExportCategory => {
+  const result: JsonExportCategory = { type: record.type, name: record.name };
+  if (record.parent_name) result.parent = record.parent_name;
+  if (record.description) result.description = record.description;
+  return result;
+};
 
-  for (const row of rows) {
-    if (!row.category_name) continue;
+export const bankAccountRecordToJsonExportBankAccount = (
+  record: BankAccountExportRecord
+): JsonExportBankAccount => {
+  const result: JsonExportBankAccount = { name: record.name };
+  if (record.description) result.description = record.description;
+  return result;
+};
 
-    const category: JsonExportCategory = row.category_parent_name
-      ? { type: row.type, name: row.category_name, parent: row.category_parent_name }
-      : { type: row.type, name: row.category_name };
+export const tagRecordToJsonExportTag = (record: TagExportRecord): JsonExportTag => {
+  const result: JsonExportTag = { name: record.name };
+  if (record.description) result.description = record.description;
+  return result;
+};
 
-    // JSON-encode the tuple rather than joining on a separator: a category
-    // name is free text and could otherwise collide with a different
-    // (parent, name) pair, silently dropping one from the export.
-    const key = JSON.stringify([
-      category.type,
-      category.parent ?? null,
-      category.name,
-    ]);
-    if (!seen.has(key)) seen.set(key, category);
-  }
-
-  return [...seen.values()].sort((a, b) => {
+const sortJsonExportCategories = (
+  categories: JsonExportCategory[]
+): JsonExportCategory[] =>
+  [...categories].sort((a, b) => {
     if (a.type !== b.type) return a.type.localeCompare(b.type);
     const parentCompare = (a.parent ?? "").localeCompare(b.parent ?? "");
     return parentCompare !== 0 ? parentCompare : a.name.localeCompare(b.name);
   });
-};
 
-const collectUniqueNames = (
+const sortByName = <T extends { name: string }>(items: T[]): T[] =>
+  [...items].sort((a, b) => a.name.localeCompare(b.name));
+
+export const buildJsonExport = (
   rows: TransactionExportRow[],
-  getNames: (row: TransactionExportRow) => Iterable<string | null | undefined>
-): { name: string }[] => {
-  const names = new Set<string>();
-  for (const row of rows) {
-    for (const name of getNames(row)) {
-      if (name) names.add(name);
-    }
-  }
-  return [...names].sort((a, b) => a.localeCompare(b)).map((name) => ({ name }));
-};
-
-export const collectJsonExportBankAccounts = (
-  rows: TransactionExportRow[]
-): JsonExportBankAccount[] => collectUniqueNames(rows, (row) => [row.bank_account_name]);
-
-export const collectJsonExportTags = (rows: TransactionExportRow[]): JsonExportTag[] =>
-  collectUniqueNames(rows, (row) => row.tag_names);
-
-export const buildJsonExport = (rows: TransactionExportRow[]): string => {
+  metadata: ExportMetadata
+): string => {
   const payload: JsonExportPayload = {
-    categories: collectJsonExportCategories(rows),
-    bank_accounts: collectJsonExportBankAccounts(rows),
-    tags: collectJsonExportTags(rows),
+    categories: sortJsonExportCategories(
+      metadata.categories.map(categoryRecordToJsonExportCategory)
+    ),
+    bank_accounts: sortByName(
+      metadata.bank_accounts.map(bankAccountRecordToJsonExportBankAccount)
+    ),
+    tags: sortByName(metadata.tags.map(tagRecordToJsonExportTag)),
     transactions: rows.map(transactionToJsonExportRow),
   };
   return JSON.stringify(payload, null, 2);

--- a/docs/superpowers/plans/2026-08-10-json-export-import-full-restore.md
+++ b/docs/superpowers/plans/2026-08-10-json-export-import-full-restore.md
@@ -1,0 +1,75 @@
+# JSON export/import as full system restore — design note & compatibility assessment
+
+**Date:** 2026-08-10
+**Status:** Not started (design decision + assessment only; no implementation tasks below have landed)
+**Source:** Follow-up to [`2026-08-01-json-category-hierarchy-import-export.md`](2026-08-01-json-category-hierarchy-import-export.md) and PR #266 (JSON export now includes the full `categories`/`bank_accounts`/`tags` library with descriptions, not just names derived from exported transactions).
+**Scope:** Lock in the requirement that a JSON export, paired with a fresh/reset account, must reproduce the entire account state — not just transactions. Assess whether the schema this implies is compatible with the schema already used for `bulk_upload_data`, whose payloads today come from two producers: this app's own JSON export, and the separate `moneylens-converter-rs` utility (ODS → JSON). CSV export is explicitly out of scope — it has never carried anything but transaction rows and isn't expected to.
+
+## Progress Log
+
+<!-- Newest entry first. One entry per session, even sessions with no code progress. -->
+
+- **2026-08-10** — Doc created at the user's request, alongside a compatibility assessment (see below). No code changes in this session. Captures a real gap: budgets have no representation anywhere in `bulk_upload_data` or JSON export today.
+
+---
+
+## Decision: JSON export/import is a full restore, CSV is not
+
+**The requirement, as stated by the user:** exporting to JSON and re-importing that file (into an empty/reset account) should be treated as a **system restore** — everything the user can see about their data model should survive the round trip: transactions (including notes), tags (including descriptions), bank accounts (including descriptions), categories (including descriptions and parent/child hierarchy), and budgets. This is explicitly a JSON-only guarantee; CSV export has never carried anything beyond flat transaction rows and this doc doesn't change that.
+
+This reframes what "the JSON export/import schema" is for. It has, so far, evolved feature-by-feature (transactions → categories → full category/account/tag library with descriptions, across the three plans referenced above). This doc's purpose is to name the destination explicitly so future schema changes get measured against it, and to check that destination doesn't conflict with the schema's second, external producer.
+
+## Where the round trip stands today (after PR #266)
+
+| Entity | Export includes | Import (`bulk_upload_data`) accepts | Restore-complete? |
+|---|---|---|---|
+| Transactions | date, type, amount, category path, bank_account, tags, notes | same, all optional except date/type/amount | Yes |
+| Categories | type, name, description, parent | same (`CategoryInput.parent` added 2026-08-01) | Yes |
+| Bank accounts | name, description | name, description | Yes |
+| Tags | name, description | name, description | Yes |
+| Budgets | **not exported** | **no `budgets` section exists in `bulk_upload_data` at all** | **No — full gap** |
+
+Budgets (`budgets` table: `name`, `type`, `target_amount`, `start_date`, `end_date`, `description`, plus many-to-many links to categories via `budget_categories` and tags via `budget_tags`) have no representation on either side. This is the one place the "everything survives the round trip" goal is not met, and it's a gap in both directions (export doesn't emit them, import has nowhere to put them).
+
+**Also worth naming as a restore-semantics gap, not a schema gap:** `bulk_upload_data` never upserts — `transactions_inserted` is "always insert" per `docs/api/bulk-upload.md`'s Idempotency table, and categories/bank_accounts/tags are `ON CONFLICT DO NOTHING` (skip, not update). So "restore" isn't a property of the import call in isolation — re-importing into a non-empty account creates duplicate transactions. The existing Danger Zone `resetUserData` RPC (wired up in `apps/web-next/src/pages/settings/index.tsx`) is what makes a JSON export a true restore: the supported restore workflow is **reset, then import**, not "import" alone. If this doc's requirement is taken literally as a product feature (a single "Restore from backup" button), that pairing needs to be explicit in the UI, not just an implied two-step manual process.
+
+## Compatibility assessment: does this conflict with the `moneylens-converter-rs`-sourced schema?
+
+**Context supplied by the user:** `bulk_upload_data`'s payload schema is also the target format for a separate utility, `moneylens-converter-rs`, which converts multi-sheet OpenDocument (ODS) spreadsheets into JSON matching this same shape — but with fewer fields available, since an ODS workbook doesn't carry tag descriptions, bank account descriptions, category descriptions, or budgets at all.
+
+**Finding: no conflict, and none is expected going forward, as long as one rule holds.** Every field this app's JSON export has ever added — `categories[].description`, `categories[].parent`, `bank_accounts[].description`, `tags[].description` — was added as **optional** on the `bulk_upload_data` side first (see `docs/api/bulk-upload.md`'s `CategoryInput`/`BankAccountInput`/`TagInput`: only `name` and, for categories, `type` are required). A `moneylens-converter-rs` payload that omits `description` entirely, or omits a `categories`/`bank_accounts`/`tags` section altogether, is already a valid subset of the schema and needs no converter-side change to keep working. The two producers aren't required to emit the same shape — they're required to emit shapes the same *consumer* (`insert_categories`/`insert_bank_accounts`/`insert_tags`/`bulk_insert_transactions`) accepts, and optionality is what makes that possible without coordinating a release between two separate codebases.
+
+**The rule to hold going forward:** any field added to satisfy "full restore" (starting with a future `budgets` section) must be **additive and optional** at the `bulk_upload_data` level — a new top-level `budgets?: BudgetInput[]` key that `moneylens-converter-rs` simply never emits, not a change to the meaning or requiredness of an existing field. Under that rule, `moneylens-converter-rs` doesn't need to be updated in lockstep with this app's export schema; it only needs updating if someone chooses to *add* budget support to the ODS conversion, which is a separate, external decision outside this repo's control. If that rule is ever violated (e.g. a field changes from optional to required, or an existing field's meaning changes), a `moneylens-converter-rs`-sourced payload would silently start failing validation — that's the one thing to watch for in future schema changes here.
+
+**Caveat:** this assessment is based on `moneylens-converter-rs`'s described output shape as relayed by the user, not by reading that tool's source (it lives outside this repository). If its actual output schema differs from "categories/bank_accounts/tags/transactions, same shape as `BulkUploadPayload`, minus description/parent/budgets," this assessment should be re-verified directly against that tool.
+
+---
+
+## Implementation order
+
+Nothing in this doc has been implemented yet — this session was documentation only, at the user's request. Future work, if picked up:
+
+- [ ] 1. Design a `budgets` section for both JSON export and `bulk_upload_data` (new `BudgetInput` with `name`, `type`, `target_amount`, `start_date?`, `end_date?`, `description?`, `categories?: string[]`, `tags?: string[]` — resolved the same way transactions resolve `category`/`bank_account`/`tags`, against the same-payload `categories`/`tags` sections or existing live rows)
+- [ ] 2. Migration: new `insert_budgets` helper (mirroring `insert_categories`/`insert_bank_accounts`/`insert_tags`) plus wiring into `bulk_upload_data`, with pgTAP coverage
+- [ ] 3. `apps/web-next/src/utility/exportMetadata.ts`: fetch budgets (+ linked category/tag names) from `budgets_with_linked` (already exists, per `database.types.ts`) alongside the existing three metadata queries
+- [ ] 4. `apps/web-next/src/utility/jsonExport.ts`: add `budgets` to `JsonExportPayload`, following the same "full library, optional description" shape as categories/bank_accounts/tags
+- [ ] 5. `docs/api/bulk-upload.md`: document `BudgetInput`, its validation/error messages, and update the "full restore" framing in the FAQ
+- [ ] 6. Decide whether "restore" becomes an explicit product feature (a single guided reset+import flow in Settings) or stays the current implicit two-step (manual reset, then manual import) — this is a product decision, not purely technical, and belongs in its own plan if pursued
+- [ ] 7. If pursuing item 6, add e2e coverage for the full round trip: export everything → reset → import → diff against a snapshot taken before reset
+
+## Critical files
+
+- `docs/api/bulk-upload.md` — payload schema source of truth; any `budgets` addition documents here first
+- `apps/web-next/src/utility/jsonExport.ts`, `exportMetadata.ts` — export side
+- `apps/web-next/src/utility/rpc.ts` — `BulkUploadPayload`/`CategoryInput`/etc. TypeScript types, `resetUserData`
+- `apps/web-next/src/pages/settings/index.tsx` — Import & Export UI, Danger Zone reset UI
+- `supabase/migrations/` — wherever `insert_categories`/`insert_bank_accounts`/`insert_tags`/`bulk_upload_data` currently live, for the future `insert_budgets` addition
+- Database: `budgets`, `budget_categories`, `budget_tags`, `budgets_with_linked` (view)
+
+## Verification plan
+
+For this session: none — no code changed. For future work items above, once picked up:
+1. `supabase test db` — new pgTAP coverage for `insert_budgets`
+2. `cd apps/web-next && npm run test:unit` — updated `jsonExport.test.ts`/`exportMetadata.test.ts`
+3. Manual: export JSON from an account with at least one budget (linked to a category and a tag), reset the account, re-import the export, confirm the budget and its links reappear identically
+4. Re-confirm the compatibility assessment above by locating and reading `moneylens-converter-rs`'s actual output schema, if/when it's accessible from this environment


### PR DESCRIPTION
## Why

The transactions JSON export only emitted `categories` and `transactions`, while the CSV export never carried these auxiliary records at all — which was fine for CSV. For JSON, this created an asymmetry with the bulk import format: an import file (`BulkUploadPayload`) can include `categories`, `bank_accounts`, and `tags` sections, but a JSON export of the same data would drop the `bank_accounts` and `tags` a user had created, breaking round-trip parity (export → re-import wouldn't recreate bank accounts/tags with no transactions referencing them, and lost the dedicated top-level listing of the ones that were referenced).

## What Changed

- Files or areas updated: `apps/web-next/src/utility/jsonExport.ts`, `apps/web-next/src/utility/jsonExport.test.ts`
- New functionality added: `collectJsonExportBankAccounts` and `collectJsonExportTags`, which derive deduped, alphabetically-sorted `{ name }` lists from the exported transaction rows, mirroring the existing `collectJsonExportCategories` pattern.
- Existing behavior changed: `buildJsonExport` (and `JsonExportPayload`) now emit `bank_accounts` and `tags` arrays alongside `categories` and `transactions`, matching the shape the bulk import RPC expects.

## Key Decisions

- Decision: Derive bank accounts/tags from the same `TransactionExportRow[]` already fetched for the export, rather than issuing separate queries.
- Reasoning: `transactions_with_details` already exposes `bank_account_name` and `tag_names` per row, so this keeps the export a pure function of the rows it already has — consistent with how `categories` are derived — and avoids extra round trips or new permissions.
- Alternatives considered: Fetching the user's full `bank_accounts`/`tags` tables directly. Rejected because it would include accounts/tags with no transactions in the exported range, which doesn't match the "export what's in this date range" semantics, and diverges from how `categories` is already scoped to referenced rows.

## How This Affects the System

- User-facing changes: JSON exports now include `bank_accounts` and `tags` sections, so a downstream JSON import can round-trip these records instead of silently dropping them.
- API changes: None. Only the client-side `JsonExportPayload` shape changed (additive fields).
- Performance implications: Negligible — dedup/sort over data already in memory, no additional queries.
- Database changes: None.
- Breaking changes: None — the new fields are additive. `bank_accounts`/`tags` don't carry a `description`, since the underlying view doesn't expose one; the import format already treats `description` as optional.

## Testing

- New tests added: `collectJsonExportBankAccounts` and `collectJsonExportTags` describe blocks (dedup, sort, empty-row handling).
- Existing tests status: Updated `buildJsonExport` assertions to include the new `bank_accounts`/`tags` fields; all 25 tests in `jsonExport.test.ts` pass.
- Manual testing performed: Ran `npm run check-types` (clean) and `npx vitest run src/utility/jsonExport.test.ts` (25/25 passed).
- Edge cases tested: rows with no bank account/tags, repeated names across rows, name collisions requiring dedup, alphabetical sort ordering.
- Test files modified or added: `apps/web-next/src/utility/jsonExport.test.ts`